### PR TITLE
VIDSOL-474: Meeting room toast is shown below the top safe area inset

### DIFF
--- a/VERA/VERACore/VERACore/Meeting room/UI/View/MeetingRoomScreen.swift
+++ b/VERA/VERACore/VERACore/Meeting room/UI/View/MeetingRoomScreen.swift
@@ -47,16 +47,18 @@ public struct MeetingRoomScreen: View {
                 }
             }
 
-            VStack {
-                if showToast, let toast = viewModel.toast {
-                    toast.view
-                        .padding(.top, 16)
-                        .transition(.move(edge: .top).combined(with: .opacity))
+            GeometryReader { geometry in
+                VStack {
+                    if showToast, let toast = viewModel.toast {
+                        toast.view
+                            .padding(.top, geometry.safeAreaInsets.top)
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                    }
+                    Spacer()
                 }
-
-                Spacer()
+                .frame(maxWidth: .infinity)
             }
-            .zIndex(999)
+            .allowsHitTesting(false)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .alert(item: $viewModel.error) { $0.view }


### PR DESCRIPTION
#### What is this PR doing?
Lowers the position in which the toast alerts are shown to not interfere with the top bar items.

#### How should this be manually tested?
You can trigger a toast by going to a meeting room and activating plane mode.

#### What are the relevant tickets?
[VIDSOL-474](https://jira.vonage.com/browse/VIDSOL-474)

#### Justification for skipping ci, if applied?

Before
<img width="645" height="1398" alt="IMG_5591" src="https://github.com/user-attachments/assets/77a237dd-5808-4275-ac77-93233441c533" />

After
<img width="1290" height="2796" alt="IMG_5593" src="https://github.com/user-attachments/assets/5dde8533-fa8f-49b6-9a34-a8c23ace7577" />


