### PR TITLE
VIDSOL-312: Black participants in active speaker layout

### DIFF
--- a/VERA/VERACore/VERACore/Meeting room/UI/View/ActiveSpeakerLayout.swift
+++ b/VERA/VERACore/VERACore/Meeting room/UI/View/ActiveSpeakerLayout.swift
@@ -5,6 +5,28 @@
 import SwiftUI
 import VERADomain
 
+// MARK: - Layout Constants
+
+/// Constants used for active speaker layout calculations
+enum ActiveSpeakerLayoutConstants {
+    /// Standard 16:9 video aspect ratio
+    static let aspectRatio: Double = 16.0 / 9.0
+    /// Width ratio for the main/active speaker tile
+    static let mainParticipantWidthRatio: Double = 0.70
+    /// Width ratio for the sidebar containing other participants
+    static let sidebarWidthRatio: Double = 0.30
+    /// Default spacing between participant tiles
+    static let spacing: Double = 8
+    /// Minimum height for a single participant view
+    static let minSingleParticipantHeight: Double = 200
+}
+
+/// Represents the preferred layout orientation based on device size class
+private enum LayoutOrientation {
+    case horizontal
+    case vertical
+}
+
 /// Main layout view for displaying participants in an active speaker format
 ///
 /// `ActiveSpeakerLayout` provides an adaptive interface that automatically switches between
@@ -24,37 +46,36 @@ struct ActiveSpeakerLayout: View {
     let participants: [Participant]
     let activeSpeakerId: String?
 
-    let itemHeight: Double = 225
-    let minItemWidth: Double = 300
-    let spacing: Double = 8
+    /// Determines the preferred layout orientation based on device size classes
+    private var preferredLayoutOrientation: LayoutOrientation {
+        if verticalSizeClass == .compact {
+            return .horizontal
+        } else if horizontalSizeClass == .compact {
+            return .vertical
+        } else {
+            return .horizontal
+        }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if participants.count == 1 {
+            if let singleParticipant = participants.first, participants.count == 1 {
                 ParticipantVideoCard(
-                    participant: participants.first!,
+                    participant: singleParticipant,
                     activeSpeakerId: activeSpeakerId
                 )
-                .id(participants.first!.id + "_main_active")
-                .frame(maxWidth: .infinity, minHeight: 200)
-                .onAppear {
-                    participants.first?.onAppear?()
-                }
-                .onDisappear {
-                    participants.first?.onDisappear?()
-                }
+                .id(singleParticipant.id + "_main_active")
+                .frame(maxWidth: .infinity, minHeight: ActiveSpeakerLayoutConstants.minSingleParticipantHeight)
+                .trackingVisibility(of: singleParticipant)
             } else if participants.count > 1 {
                 Group {
-                    if verticalSizeClass == .compact {
+                    switch preferredLayoutOrientation {
+                    case .horizontal:
                         HorizontalActiveSpeakerLayoutView(
                             participants: participants,
                             activeSpeakerId: activeSpeakerId)
-                    } else if horizontalSizeClass == .compact {
+                    case .vertical:
                         VerticalActiveSpeakerLayoutView(
-                            participants: participants,
-                            activeSpeakerId: activeSpeakerId)
-                    } else {
-                        HorizontalActiveSpeakerLayoutView(
                             participants: participants,
                             activeSpeakerId: activeSpeakerId)
                     }
@@ -68,36 +89,30 @@ struct ActiveSpeakerLayout: View {
     }
 }
 
-public struct HorizontalActiveSpeakerLayoutView: View {
-    let spacing: Double = 8
-    private let aspectRatio: Double = 16.0 / 9.0
-
-    var activeParticipant: Participant {
-        participants.first!
-    }
-    var restOfParticipants: [Participant] {
-        Array(participants.dropFirst())
-    }
-
+struct HorizontalActiveSpeakerLayoutView: View {
     let participants: [Participant]
     let activeSpeakerId: String?
 
-    public var body: some View {
+    private var activeParticipant: Participant? {
+        participants.first
+    }
+
+    private var restOfParticipants: [Participant] {
+        Array(participants.dropFirst())
+    }
+
+    var body: some View {
         GeometryReader { outerGeometry in
-            if outerGeometry.size.width > 0 && outerGeometry.size.height > 0 {
-                HStack(spacing: 8) {
+            if outerGeometry.size.width > 0 && outerGeometry.size.height > 0,
+               let activeParticipant = activeParticipant {
+                HStack(spacing: ActiveSpeakerLayoutConstants.spacing) {
                     ParticipantVideoCard(
                         participant: activeParticipant,
                         activeSpeakerId: activeSpeakerId
                     )
                     .id(activeParticipant.id + "_main")
-                    .frame(width: max(1, outerGeometry.size.width * 0.70))
-                    .onAppear {
-                        activeParticipant.onAppear?()
-                    }
-                    .onDisappear {
-                        activeParticipant.onDisappear?()
-                    }
+                    .frame(width: max(1, outerGeometry.size.width * ActiveSpeakerLayoutConstants.mainParticipantWidthRatio))
+                    .trackingVisibility(of: activeParticipant)
 
                     GeometryReader { geometry in
                         let availableWidth = max(0, geometry.size.width)
@@ -105,10 +120,10 @@ public struct HorizontalActiveSpeakerLayoutView: View {
 
                         // Prevent NaN calculations by ensuring positive values
                         if availableWidth > 0 && availableHeight > 0 {
-                            let cellWidth = max(1, availableWidth - spacing)
-                            let cellHeight = max(1, cellWidth / aspectRatio)
+                            let cellWidth = max(1, availableWidth - ActiveSpeakerLayoutConstants.spacing)
+                            let cellHeight = max(1, cellWidth / ActiveSpeakerLayoutConstants.aspectRatio)
 
-                            let rowsVisible = max(1, Int((availableHeight + spacing) / (cellHeight + spacing)))
+                            let rowsVisible = max(1, Int((availableHeight + ActiveSpeakerLayoutConstants.spacing) / (cellHeight + ActiveSpeakerLayoutConstants.spacing)))
 
                             let maxVisibleItems = rowsVisible
 
@@ -120,20 +135,15 @@ public struct HorizontalActiveSpeakerLayoutView: View {
                             let visibleItems = Array(restOfParticipants.prefix(takeCount))
                             let hiddenItems = Array(restOfParticipants.dropFirst(takeCount))
 
-                            VStack(spacing: spacing) {
+                            VStack(spacing: ActiveSpeakerLayoutConstants.spacing) {
                                 ForEach(Array(visibleItems.enumerated()), id: \.element.id) { index, participant in
                                     ParticipantVideoCard(
                                         participant: participant,
                                         activeSpeakerId: activeSpeakerId
                                     )
                                     .id("\(participant.id)_\(index)_\(visibleItems.count)")
-                                    .aspectRatio(aspectRatio, contentMode: .fit)
-                                    .onAppear {
-                                        participant.onAppear?()
-                                    }
-                                    .onDisappear {
-                                        participant.onDisappear?()
-                                    }
+                                    .aspectRatio(ActiveSpeakerLayoutConstants.aspectRatio, contentMode: .fit)
+                                    .trackingVisibility(of: participant)
                                 }
 
                                 if !hiddenItems.isEmpty {
@@ -141,7 +151,7 @@ public struct HorizontalActiveSpeakerLayoutView: View {
                                         participantNames: hiddenItems.map { $0.name }
                                     )
                                     .id("hidden_\(hiddenItems.count)_\(visibleItems.count)")
-                                    .aspectRatio(aspectRatio, contentMode: .fit)
+                                    .aspectRatio(ActiveSpeakerLayoutConstants.aspectRatio, contentMode: .fit)
                                     .onAppear {
                                         hiddenItems.forEach { $0.onDisappear?() }
                                     }
@@ -152,7 +162,7 @@ public struct HorizontalActiveSpeakerLayoutView: View {
                             EmptyView()
                         }
                     }
-                    .frame(width: max(1, outerGeometry.size.width * 0.30))
+                    .frame(width: max(1, outerGeometry.size.width * ActiveSpeakerLayoutConstants.sidebarWidthRatio))
                 }
             } else {
                 EmptyView()
@@ -161,33 +171,27 @@ public struct HorizontalActiveSpeakerLayoutView: View {
     }
 }
 
-public struct VerticalActiveSpeakerLayoutView: View {
-    let itemHeight: Double = 200 * 3 / 4
-    let minItemWidth: Double = 200
-    let spacing: Double = 0
-
-    var activeParticipant: Participant {
-        participants.first!
-    }
-    var restOfParticipants: [Participant] {
-        Array(participants.dropFirst())
-    }
-
+struct VerticalActiveSpeakerLayoutView: View {
     let participants: [Participant]
     let activeSpeakerId: String?
 
-    public var body: some View {
-        VStack(spacing: 8) {
-            ParticipantVideoCard(
-                participant: activeParticipant,
-                activeSpeakerId: activeSpeakerId
-            )
-            .id(activeParticipant.id + "_main")
-            .onAppear {
-                activeParticipant.onAppear?()
-            }
-            .onDisappear {
-                activeParticipant.onDisappear?()
+    private var activeParticipant: Participant? {
+        participants.first
+    }
+
+    private var restOfParticipants: [Participant] {
+        Array(participants.dropFirst())
+    }
+
+    var body: some View {
+        VStack(spacing: ActiveSpeakerLayoutConstants.spacing) {
+            if let activeParticipant = activeParticipant {
+                ParticipantVideoCard(
+                    participant: activeParticipant,
+                    activeSpeakerId: activeSpeakerId
+                )
+                .id(activeParticipant.id + "_main")
+                .trackingVisibility(of: activeParticipant)
             }
 
             Group {
@@ -197,12 +201,7 @@ public struct VerticalActiveSpeakerLayoutView: View {
                         activeSpeakerId: activeSpeakerId
                     )
                     .id(restOfParticipants[0].id + "_other")
-                    .onAppear {
-                        restOfParticipants[0].onAppear?()
-                    }
-                    .onDisappear {
-                        restOfParticipants[0].onDisappear?()
-                    }
+                    .trackingVisibility(of: restOfParticipants[0])
                 } else if restOfParticipants.count == 2 {
                     HStack {
                         ParticipantVideoCard(
@@ -210,24 +209,14 @@ public struct VerticalActiveSpeakerLayoutView: View {
                             activeSpeakerId: activeSpeakerId
                         )
                         .id(restOfParticipants[0].id + "_other")
-                        .onAppear {
-                            restOfParticipants[0].onAppear?()
-                        }
-                        .onDisappear {
-                            restOfParticipants[0].onDisappear?()
-                        }
+                        .trackingVisibility(of: restOfParticipants[0])
 
                         ParticipantVideoCard(
                             participant: restOfParticipants[1],
                             activeSpeakerId: activeSpeakerId
                         )
                         .id(restOfParticipants[1].id + "_other")
-                        .onAppear {
-                            restOfParticipants[1].onAppear?()
-                        }
-                        .onDisappear {
-                            restOfParticipants[1].onDisappear?()
-                        }
+                        .trackingVisibility(of: restOfParticipants[1])
                     }
                     .transition(.slide)
                 } else if restOfParticipants.count >= 3 {
@@ -237,12 +226,7 @@ public struct VerticalActiveSpeakerLayoutView: View {
                             activeSpeakerId: activeSpeakerId
                         )
                         .id(restOfParticipants[0].id + "_other")
-                        .onAppear {
-                            restOfParticipants[0].onAppear?()
-                        }
-                        .onDisappear {
-                            restOfParticipants[0].onDisappear?()
-                        }
+                        .trackingVisibility(of: restOfParticipants[0])
 
                         let hiddenParticipants = Array(restOfParticipants.dropFirst())
                         HiddenParticipantsTile(

--- a/VERA/VERACore/VERACore/Meeting room/UI/View/ActiveSpeakerLayout.swift
+++ b/VERA/VERACore/VERACore/Meeting room/UI/View/ActiveSpeakerLayout.swift
@@ -40,6 +40,9 @@ struct ActiveSpeakerLayout: View {
                 .onAppear {
                     participants.first?.onAppear?()
                 }
+                .onDisappear {
+                    participants.first?.onDisappear?()
+                }
             } else if participants.count > 1 {
                 Group {
                     if verticalSizeClass == .compact {
@@ -89,6 +92,12 @@ public struct HorizontalActiveSpeakerLayoutView: View {
                     )
                     .id(activeParticipant.id + "_main")
                     .frame(width: max(1, outerGeometry.size.width * 0.70))
+                    .onAppear {
+                        activeParticipant.onAppear?()
+                    }
+                    .onDisappear {
+                        activeParticipant.onDisappear?()
+                    }
 
                     GeometryReader { geometry in
                         let availableWidth = max(0, geometry.size.width)
@@ -119,6 +128,12 @@ public struct HorizontalActiveSpeakerLayoutView: View {
                                     )
                                     .id("\(participant.id)_\(index)_\(visibleItems.count)")
                                     .aspectRatio(aspectRatio, contentMode: .fit)
+                                    .onAppear {
+                                        participant.onAppear?()
+                                    }
+                                    .onDisappear {
+                                        participant.onDisappear?()
+                                    }
                                 }
 
                                 if !hiddenItems.isEmpty {
@@ -127,14 +142,12 @@ public struct HorizontalActiveSpeakerLayoutView: View {
                                     )
                                     .id("hidden_\(hiddenItems.count)_\(visibleItems.count)")
                                     .aspectRatio(aspectRatio, contentMode: .fit)
+                                    .onAppear {
+                                        hiddenItems.forEach { $0.onDisappear?() }
+                                    }
                                 }
                             }
                             .frame(maxHeight: .infinity, alignment: .center)
-                            .onAppear {
-                                hiddenItems.forEach { $0.onDisappear?() }
-                                activeParticipant.onAppear?()
-                                visibleItems.forEach { $0.onAppear?() }
-                            }
                         } else {
                             EmptyView()
                         }
@@ -170,6 +183,12 @@ public struct VerticalActiveSpeakerLayoutView: View {
                 activeSpeakerId: activeSpeakerId
             )
             .id(activeParticipant.id + "_main")
+            .onAppear {
+                activeParticipant.onAppear?()
+            }
+            .onDisappear {
+                activeParticipant.onDisappear?()
+            }
 
             Group {
                 if restOfParticipants.count == 1 {
@@ -179,8 +198,10 @@ public struct VerticalActiveSpeakerLayoutView: View {
                     )
                     .id(restOfParticipants[0].id + "_other")
                     .onAppear {
-                        activeParticipant.onAppear?()
                         restOfParticipants[0].onAppear?()
+                    }
+                    .onDisappear {
+                        restOfParticipants[0].onDisappear?()
                     }
                 } else if restOfParticipants.count == 2 {
                     HStack {
@@ -189,6 +210,12 @@ public struct VerticalActiveSpeakerLayoutView: View {
                             activeSpeakerId: activeSpeakerId
                         )
                         .id(restOfParticipants[0].id + "_other")
+                        .onAppear {
+                            restOfParticipants[0].onAppear?()
+                        }
+                        .onDisappear {
+                            restOfParticipants[0].onDisappear?()
+                        }
 
                         ParticipantVideoCard(
                             participant: restOfParticipants[1],
@@ -196,9 +223,10 @@ public struct VerticalActiveSpeakerLayoutView: View {
                         )
                         .id(restOfParticipants[1].id + "_other")
                         .onAppear {
-                            activeParticipant.onAppear?()
-                            restOfParticipants[0].onAppear?()
                             restOfParticipants[1].onAppear?()
+                        }
+                        .onDisappear {
+                            restOfParticipants[1].onDisappear?()
                         }
                     }
                     .transition(.slide)
@@ -209,6 +237,12 @@ public struct VerticalActiveSpeakerLayoutView: View {
                             activeSpeakerId: activeSpeakerId
                         )
                         .id(restOfParticipants[0].id + "_other")
+                        .onAppear {
+                            restOfParticipants[0].onAppear?()
+                        }
+                        .onDisappear {
+                            restOfParticipants[0].onDisappear?()
+                        }
 
                         let hiddenParticipants = Array(restOfParticipants.dropFirst())
                         HiddenParticipantsTile(
@@ -218,8 +252,6 @@ public struct VerticalActiveSpeakerLayoutView: View {
                         .transition(.opacity)
                         .onAppear {
                             hiddenParticipants.forEach { $0.onDisappear?() }
-                            activeParticipant.onAppear?()
-                            restOfParticipants[0].onAppear?()
                         }
                     }
                     .transition(.slide)

--- a/VERA/VERACore/VERACore/Meeting room/UI/View/ActiveSpeakerLayout.swift
+++ b/VERA/VERACore/VERACore/Meeting room/UI/View/ActiveSpeakerLayout.swift
@@ -279,9 +279,6 @@ struct SidebarParticipantsView: View {
                 )
                 .id("hidden_\(hiddenParticipants.count)_\(visibleParticipants.count)")
                 .aspectRatio(ActiveSpeakerLayoutConstants.aspectRatio, contentMode: .fit)
-                .onAppear {
-                    hiddenParticipants.forEach { $0.onDisappear?() }
-                }
             }
         }
         .frame(maxHeight: .infinity, alignment: .center)
@@ -366,9 +363,6 @@ struct VerticalActiveSpeakerLayoutView: View {
                         )
                         .id("hidden_participants")
                         .transition(.opacity)
-                        .onAppear {
-                            hiddenParticipants.forEach { $0.onDisappear?() }
-                        }
                     }
                     .transition(.slide)
                 }

--- a/VERA/VERACore/VERACore/Meeting room/UI/View/ActiveSpeakerLayout.swift
+++ b/VERA/VERACore/VERACore/Meeting room/UI/View/ActiveSpeakerLayout.swift
@@ -7,7 +7,11 @@ import VERADomain
 
 // MARK: - Layout Constants
 
-/// Constants used for active speaker layout calculations
+/// Configuration constants for the Active Speaker layout.
+///
+/// These values control the visual appearance and behavior of the layout,
+/// including tile sizing, spacing, and aspect ratios. Centralized here for
+/// easy adjustment and consistency across all layout components.
 enum ActiveSpeakerLayoutConstants {
     /// Standard 16:9 video aspect ratio
     static let aspectRatio: Double = 16.0 / 9.0
@@ -19,26 +23,75 @@ enum ActiveSpeakerLayoutConstants {
     static let spacing: Double = 8
     /// Minimum height for a single participant view
     static let minSingleParticipantHeight: Double = 200
+    /// Bottom padding for the layout container
+    static let bottomPadding: Double = 4
+    /// Horizontal padding for the layout container
+    static let horizontalPadding: Double = 12
 }
 
-/// Represents the preferred layout orientation based on device size class
+// MARK: - Layout Info
+
+/// Pre-calculated layout information for sidebar participant positioning.
+///
+/// This struct is computed based on available screen space and determines
+/// how many participant tiles can be displayed before overflow handling kicks in.
+/// Used by `SidebarParticipantsView` to render the appropriate number of tiles.
+struct SidebarLayoutInfo {
+    /// Number of participants that can be displayed in the sidebar
+    let visibleCount: Int
+
+    /// Total number of participants (excluding active speaker)
+    let totalCount: Int
+
+    /// Returns `true` if some participants will be collapsed into the overflow tile
+    var hasHiddenParticipants: Bool {
+        visibleCount < totalCount
+    }
+}
+
+/// Layout orientation options based on device size class.
 private enum LayoutOrientation {
+    /// Horizontal layout with main speaker on left, sidebar on right (iPad/landscape)
     case horizontal
+    /// Vertical layout with main speaker on top, others below (iPhone/portrait)
     case vertical
 }
 
-/// Main layout view for displaying participants in an active speaker format
+// MARK: - Active Speaker Layout
+
+/// A video conferencing layout that emphasizes the current active speaker.
 ///
-/// `ActiveSpeakerLayout` provides an adaptive interface that automatically switches between
-/// horizontal and vertical layouts based on SwiftUI's environment size classes. The layout
-/// intelligently calculates available space to determine how many participants can be displayed,
-/// automatically collapsing excess participants into a summary tile showing their initials.
+/// `ActiveSpeakerLayout` displays participants in a format optimized for meetings
+/// where one person speaks at a time. The active speaker receives the largest tile
+/// (70% width in horizontal mode), while other participants appear in a sidebar.
 ///
-/// Uses `onAppear` and `onDisappear` callbacks to activate or deactivate participant video streams.
-/// When a participant becomes visible, `onAppear` enables their video stream.
-/// When a participant is hidden, `onDisappear` disables their video stream to optimize bandwidth.
+/// ## Layout Behavior
 ///
-/// Be careful with animations, it may impact video rendering
+/// The layout automatically adapts based on device size class:
+/// - **Horizontal** (iPad, landscape): Main speaker left, sidebar right
+/// - **Vertical** (iPhone, portrait): Main speaker top, others bottom
+///
+/// ## Participant Overflow
+///
+/// When more participants exist than can fit in the sidebar, excess participants
+/// are collapsed into a `HiddenParticipantsTile` showing their initials.
+///
+/// ## Video Stream Management
+///
+/// Uses `.trackingVisibility(of:)` modifier to optimize bandwidth:
+/// - Visible participants have their video streams enabled via `onAppear`
+/// - Hidden participants have streams disabled via `onDisappear`
+///
+/// ## Usage
+///
+/// ```swift
+/// ActiveSpeakerLayout(
+///     participants: meeting.participants,
+///     activeSpeakerId: meeting.currentSpeakerId
+/// )
+/// ```
+///
+/// - Note: Avoid applying animations that could interfere with video rendering.
 struct ActiveSpeakerLayout: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.verticalSizeClass) var verticalSizeClass
@@ -83,12 +136,24 @@ struct ActiveSpeakerLayout: View {
                 .transition(.identity)
             }
         }
-        .padding(.bottom, 4)
-        .padding(.horizontal, 12)
+        .padding(.bottom, ActiveSpeakerLayoutConstants.bottomPadding)
+        .padding(.horizontal, ActiveSpeakerLayoutConstants.horizontalPadding)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
     }
 }
 
+// MARK: - Horizontal Layout
+
+/// Horizontal variant of the active speaker layout for wider screens.
+///
+/// Displays the active speaker in a large tile on the left (70% width) with
+/// remaining participants stacked vertically in a sidebar on the right (30% width).
+/// Automatically calculates how many participants fit in the sidebar based on
+/// available height and the 16:9 aspect ratio.
+///
+/// Used when:
+/// - `verticalSizeClass == .compact` (landscape orientation)
+/// - `horizontalSizeClass == .regular` (iPad)
 struct HorizontalActiveSpeakerLayoutView: View {
     let participants: [Participant]
     let activeSpeakerId: String?
@@ -102,75 +167,142 @@ struct HorizontalActiveSpeakerLayoutView: View {
     }
 
     var body: some View {
-        GeometryReader { outerGeometry in
-            if outerGeometry.size.width > 0 && outerGeometry.size.height > 0,
-               let activeParticipant = activeParticipant {
+        GeometryReader { geometry in
+            if geometry.size.width > 0 && geometry.size.height > 0,
+                let activeParticipant = activeParticipant
+            {
+                let mainWidth = geometry.size.width * ActiveSpeakerLayoutConstants.mainParticipantWidthRatio
+                let sidebarWidth = geometry.size.width * ActiveSpeakerLayoutConstants.sidebarWidthRatio
+                let layoutInfo = calculateSidebarLayout(
+                    sidebarWidth: sidebarWidth,
+                    availableHeight: geometry.size.height,
+                    participantCount: restOfParticipants.count
+                )
+
                 HStack(spacing: ActiveSpeakerLayoutConstants.spacing) {
                     ParticipantVideoCard(
                         participant: activeParticipant,
                         activeSpeakerId: activeSpeakerId
                     )
                     .id(activeParticipant.id + "_main")
-                    .frame(width: max(1, outerGeometry.size.width * ActiveSpeakerLayoutConstants.mainParticipantWidthRatio))
+                    .frame(width: max(1, mainWidth))
                     .trackingVisibility(of: activeParticipant)
 
-                    GeometryReader { geometry in
-                        let availableWidth = max(0, geometry.size.width)
-                        let availableHeight = max(0, geometry.size.height)
-
-                        // Prevent NaN calculations by ensuring positive values
-                        if availableWidth > 0 && availableHeight > 0 {
-                            let cellWidth = max(1, availableWidth - ActiveSpeakerLayoutConstants.spacing)
-                            let cellHeight = max(1, cellWidth / ActiveSpeakerLayoutConstants.aspectRatio)
-
-                            let rowsVisible = max(1, Int((availableHeight + ActiveSpeakerLayoutConstants.spacing) / (cellHeight + ActiveSpeakerLayoutConstants.spacing)))
-
-                            let maxVisibleItems = rowsVisible
-
-                            let takeCount =
-                                maxVisibleItems >= restOfParticipants.count
-                                ? restOfParticipants.count
-                                : max(1, maxVisibleItems - 1)
-
-                            let visibleItems = Array(restOfParticipants.prefix(takeCount))
-                            let hiddenItems = Array(restOfParticipants.dropFirst(takeCount))
-
-                            VStack(spacing: ActiveSpeakerLayoutConstants.spacing) {
-                                ForEach(Array(visibleItems.enumerated()), id: \.element.id) { index, participant in
-                                    ParticipantVideoCard(
-                                        participant: participant,
-                                        activeSpeakerId: activeSpeakerId
-                                    )
-                                    .id("\(participant.id)_\(index)_\(visibleItems.count)")
-                                    .aspectRatio(ActiveSpeakerLayoutConstants.aspectRatio, contentMode: .fit)
-                                    .trackingVisibility(of: participant)
-                                }
-
-                                if !hiddenItems.isEmpty {
-                                    HiddenParticipantsTile(
-                                        participantNames: hiddenItems.map { $0.name }
-                                    )
-                                    .id("hidden_\(hiddenItems.count)_\(visibleItems.count)")
-                                    .aspectRatio(ActiveSpeakerLayoutConstants.aspectRatio, contentMode: .fit)
-                                    .onAppear {
-                                        hiddenItems.forEach { $0.onDisappear?() }
-                                    }
-                                }
-                            }
-                            .frame(maxHeight: .infinity, alignment: .center)
-                        } else {
-                            EmptyView()
-                        }
-                    }
-                    .frame(width: max(1, outerGeometry.size.width * ActiveSpeakerLayoutConstants.sidebarWidthRatio))
+                    SidebarParticipantsView(
+                        participants: restOfParticipants,
+                        layoutInfo: layoutInfo,
+                        activeSpeakerId: activeSpeakerId
+                    )
+                    .frame(width: max(1, sidebarWidth))
                 }
-            } else {
-                EmptyView()
             }
-        }.frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Layout Calculation
+
+    /// Calculates how many participants can fit in the sidebar based on available space
+    /// - Parameters:
+    ///   - sidebarWidth: The available width for the sidebar
+    ///   - availableHeight: The available height for the sidebar
+    ///   - participantCount: The total number of participants to display
+    /// - Returns: Layout information containing visible count
+    private func calculateSidebarLayout(
+        sidebarWidth: CGFloat,
+        availableHeight: CGFloat,
+        participantCount: Int
+    ) -> SidebarLayoutInfo {
+        guard sidebarWidth > 0, availableHeight > 0 else {
+            return SidebarLayoutInfo(visibleCount: 0, totalCount: participantCount)
+        }
+
+        let spacing = ActiveSpeakerLayoutConstants.spacing
+        let aspectRatio = ActiveSpeakerLayoutConstants.aspectRatio
+
+        let cellWidth = max(1, sidebarWidth - spacing)
+        let cellHeight = max(1, cellWidth / aspectRatio)
+        let rowsVisible = max(1, Int((availableHeight + spacing) / (cellHeight + spacing)))
+
+        // Reserve one slot for the "hidden participants" tile if needed
+        let visibleCount: Int
+        if rowsVisible >= participantCount {
+            visibleCount = participantCount
+        } else {
+            visibleCount = max(1, rowsVisible - 1)
+        }
+
+        return SidebarLayoutInfo(visibleCount: visibleCount, totalCount: participantCount)
     }
 }
 
+// MARK: - Sidebar Participants View
+
+/// Displays non-active participants in a vertical stack with overflow handling.
+///
+/// This component renders participant video cards based on pre-calculated layout
+/// information. When more participants exist than can fit, excess participants
+/// are collapsed into a `HiddenParticipantsTile` showing their initials.
+///
+/// ## Video Stream Optimization
+///
+/// - Visible participants: Video enabled via `.trackingVisibility(of:)`
+/// - Hidden participants: Video disabled via `onDisappear` when tile appears
+struct SidebarParticipantsView: View {
+    let participants: [Participant]
+    let layoutInfo: SidebarLayoutInfo
+    let activeSpeakerId: String?
+
+    private var visibleParticipants: [Participant] {
+        Array(participants.prefix(layoutInfo.visibleCount))
+    }
+
+    private var hiddenParticipants: [Participant] {
+        Array(participants.dropFirst(layoutInfo.visibleCount))
+    }
+
+    var body: some View {
+        VStack(spacing: ActiveSpeakerLayoutConstants.spacing) {
+            ForEach(Array(visibleParticipants.enumerated()), id: \.element.id) { index, participant in
+                ParticipantVideoCard(
+                    participant: participant,
+                    activeSpeakerId: activeSpeakerId
+                )
+                .id("\(participant.id)_\(index)_\(visibleParticipants.count)")
+                .aspectRatio(ActiveSpeakerLayoutConstants.aspectRatio, contentMode: .fit)
+                .trackingVisibility(of: participant)
+            }
+
+            if !hiddenParticipants.isEmpty {
+                HiddenParticipantsTile(
+                    participantNames: hiddenParticipants.map { $0.name }
+                )
+                .id("hidden_\(hiddenParticipants.count)_\(visibleParticipants.count)")
+                .aspectRatio(ActiveSpeakerLayoutConstants.aspectRatio, contentMode: .fit)
+                .onAppear {
+                    hiddenParticipants.forEach { $0.onDisappear?() }
+                }
+            }
+        }
+        .frame(maxHeight: .infinity, alignment: .center)
+    }
+}
+
+// MARK: - Vertical Layout
+
+/// Vertical variant of the active speaker layout for narrower screens.
+///
+/// Displays the active speaker in a large tile at the top with remaining
+/// participants shown below in a horizontal arrangement. Supports up to
+/// 2 visible non-active participants before collapsing to an overflow tile.
+///
+/// ## Participant Display Rules
+///
+/// - **1 other participant**: Single tile below main speaker
+/// - **2 other participants**: Two tiles side-by-side below main speaker
+/// - **3+ other participants**: One tile + overflow tile showing remaining count
+///
+/// Used when `horizontalSizeClass == .compact` (iPhone portrait).
 struct VerticalActiveSpeakerLayoutView: View {
     let participants: [Participant]
     let activeSpeakerId: String?

--- a/VERA/VERACore/VERACore/Meeting room/UI/View/ActiveSpeakerLayout.swift
+++ b/VERA/VERACore/VERACore/Meeting room/UI/View/ActiveSpeakerLayout.swift
@@ -42,11 +42,6 @@ struct SidebarLayoutInfo {
 
     /// Total number of participants (excluding active speaker)
     let totalCount: Int
-
-    /// Returns `true` if some participants will be collapsed into the overflow tile
-    var hasHiddenParticipants: Bool {
-        visibleCount < totalCount
-    }
 }
 
 /// Layout orientation options based on device size class.
@@ -275,7 +270,7 @@ struct SidebarParticipantsView: View {
 
             if !hiddenParticipants.isEmpty {
                 HiddenParticipantsTile(
-                    participantNames: hiddenParticipants.map { $0.name }
+                    participants: hiddenParticipants
                 )
                 .id("hidden_\(hiddenParticipants.count)_\(visibleParticipants.count)")
                 .aspectRatio(ActiveSpeakerLayoutConstants.aspectRatio, contentMode: .fit)
@@ -359,7 +354,7 @@ struct VerticalActiveSpeakerLayoutView: View {
 
                         let hiddenParticipants = Array(restOfParticipants.dropFirst())
                         HiddenParticipantsTile(
-                            participantNames: hiddenParticipants.map { $0.name }
+                            participants: hiddenParticipants
                         )
                         .id("hidden_participants")
                         .transition(.opacity)

--- a/VERA/VERACore/VERACore/Meeting room/UI/View/HiddenParticipantsTile.swift
+++ b/VERA/VERACore/VERACore/Meeting room/UI/View/HiddenParticipantsTile.swift
@@ -4,16 +4,28 @@
 
 import SwiftUI
 import VERACommonUI
+import VERADomain
 
+/// A tile that displays avatars for participants who are hidden from the main video layout.
+///
+/// This component manages video stream visibility for hidden participants:
+/// - When the tile appears, `onDisappear` is called on each participant to disable their video streams
+/// - When the tile disappears (participants become visible again), `onAppear` is called to re-enable streams
+///
+/// This ensures bandwidth is not wasted on video streams for participants not currently visible.
 struct HiddenParticipantsTile: View {
-    let participantNames: [String]
+    let participants: [Participant]
     let spacedBy: CGFloat
 
+    private var participantNames: [String] {
+        participants.map { $0.name }
+    }
+
     init(
-        participantNames: [String],
+        participants: [Participant],
         spacedBy: CGFloat = -8
     ) {
-        self.participantNames = participantNames
+        self.participants = participants
         self.spacedBy = spacedBy
     }
 
@@ -34,6 +46,14 @@ struct HiddenParticipantsTile: View {
         }
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .shadow(radius: 2)
+        .onAppear {
+            // Disable video streams for hidden participants.
+            // Re-enabling is handled by ParticipantVideoCard's .trackingVisibility(of:)
+            // when participants transition back to a visible state.
+            for participant in participants {
+                participant.onDisappear?()
+            }
+        }
     }
 }
 
@@ -66,11 +86,11 @@ struct AdditionalParticipantsAvatar: View {
 struct ParticipantsPlaceholders_Previews: PreviewProvider {
     static var previews: some View {
         HiddenParticipantsTile(
-            participantNames: [
-                "Arthur Dent",
-                "Ford Prefect",
-                "Zaphod Beeblebrox",
-                "Marvin",
+            participants: [
+                PreviewData.arthurDent,
+                PreviewData.eddie,
+                PreviewData.fordPrefect,
+                PreviewData.fenchurch,
             ]
         )
         .previewLayout(.sizeThatFits)

--- a/VERA/VERACore/VERACore/Meeting room/UI/View/ParticipantVisibilityModifier.swift
+++ b/VERA/VERACore/VERACore/Meeting room/UI/View/ParticipantVisibilityModifier.swift
@@ -1,0 +1,38 @@
+//
+//  Created by Vonage on 2/6/26.
+//
+
+import SwiftUI
+import VERADomain
+
+/// A view modifier that tracks participant visibility and manages video stream subscriptions.
+///
+/// This modifier automatically calls `onAppear` when the view becomes visible and `onDisappear`
+/// when it leaves the screen, enabling bandwidth optimization by only subscribing to visible
+/// participant video streams.
+struct ParticipantVisibilityModifier: ViewModifier {
+    let participant: Participant
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                participant.onAppear?()
+            }
+            .onDisappear {
+                participant.onDisappear?()
+            }
+    }
+}
+
+extension View {
+    /// Tracks visibility of a participant and manages their video stream subscription.
+    ///
+    /// When the view appears, the participant's `onAppear` callback is invoked to enable
+    /// their video stream. When the view disappears, `onDisappear` is called to disable it.
+    ///
+    /// - Parameter participant: The participant whose visibility should be tracked.
+    /// - Returns: A view that automatically manages the participant's video subscription.
+    func trackingVisibility(of participant: Participant) -> some View {
+        modifier(ParticipantVisibilityModifier(participant: participant))
+    }
+}

--- a/VERA/VERAVonage/VERAVonage/VonageSubscriber.swift
+++ b/VERA/VERAVonage/VERAVonage/VonageSubscriber.swift
@@ -9,6 +9,19 @@ import SwiftUI
 import VERACore
 import VERADomain
 
+/// Constants used for video subscription management.
+private enum SubscriberConstants {
+    /// Delay before disabling video when a participant becomes hidden.
+    ///
+    /// This debounce interval prevents video flickering during rapid layout transitions
+    /// (e.g., when a participant moves between visible and hidden states).
+    /// The delay allows `onAppear` to cancel the disable task if the participant
+    /// reappears in a different view within this timeframe.
+    ///
+    /// - Note: 500ms balances responsiveness with transition handling.
+    static let videoDisableDebounceNanoseconds = 500
+}
+
 /// A wrapper around `OTSubscriber` that exposes reactive state, a SwiftUI view, and bandwidth controls.
 ///
 /// `VonageSubscriber` represents a single remote participant’s media stream. It provides a SwiftUI-compatible view,
@@ -71,8 +84,13 @@ public class VonageSubscriber: NSObject {
     /// Whether audio was subscribed before entering hold.
     @Published public private(set) var wasSubscribedToAudio: Bool = false
 
-    /// A delayed task that reinforces video subscription after visibility changes.
-    private var reinforcementTask: Task<Void, Never>?
+    /// Tracks the number of views currently displaying this participant.
+    /// Video is enabled when count > 0 and disabled when count reaches 0.
+    @Atomic private var visibilityCount: Int = 0
+
+    /// A delayed task that disables video subscription after visibility changes.
+    /// Uses debouncing to handle rapid layout transitions gracefully.
+    private var disableTask: Task<Void, Never>?
 
     /// Convenience for `videoDimensions.aspectRatio`.
     public var aspectRatio: Double { videoDimensions.aspectRatio }
@@ -157,19 +175,22 @@ public class VonageSubscriber: NSObject {
 
         participant.onAppear = { [weak self] in
             guard let self else { return }
-            self.setActiveSubscription(true)
-            self.reinforcementTask?.cancel()
-
-            self.reinforcementTask = Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                guard let self, !Task.isCancelled else { return }
+            self.visibilityCount += 1
+            self.disableTask?.cancel()
+            if self.visibilityCount > 0 {
                 self.setActiveSubscription(true)
             }
         }
 
         participant.onDisappear = { [weak self] in
             guard let self else { return }
-            self.setActiveSubscription(false)
+            self.visibilityCount = max(0, self.visibilityCount - 1)
+            self.disableTask?.cancel()
+            self.disableTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .milliseconds(SubscriberConstants.videoDisableDebounceNanoseconds))
+                guard let self, !Task.isCancelled, self.visibilityCount <= 0 else { return }
+                self.setActiveSubscription(false)
+            }
         }
     }
 
@@ -217,8 +238,8 @@ public class VonageSubscriber: NSObject {
         participant.onAppear = nil
         participant.onDisappear = nil
 
-        reinforcementTask?.cancel()
-        reinforcementTask = nil
+        disableTask?.cancel()
+        disableTask = nil
     }
 }
 


### PR DESCRIPTION
## What is this PR doing?

Fixes bandwidth waste and UI instability in Active Speaker layout caused by improper video subscription management when participants move between visible/hidden states.

**Changes**

- **New `ParticipantVisibilityModifier`** - Properly wires SwiftUI `onAppear`/`onDisappear` to participant visibility
- **Improved onDisappear handling** - Removed unnecessary onDisappear method calls
- **Improved geometry handling** - Added guards against zero/invalid dimensions

**Files Changed**

- `ActiveSpeakerLayout.swift`
- `ParticipantVisibilityModifier.swift` (new)

## How should this be manually tested?

- Join meeting with 3+ participants
- Switch active speakers rapidly → video should stabilize
- Verify hidden participants don't consume bandwidth

## What are the relevant tickets?

[VIDSOL-312](https://jira.vonage.com/browse/VIDSOL-312)

## Justification for skipping ci, if applied?