### PR TITLE
VIDSOL-464: Create Reactions module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,19 @@ jobs:
           -resultBundlePath DerivedData/VERADomainTests-macOS.xcresult \
           $XCODE_COMMON_FLAGS | xcpretty
 
+    - name: Run VERAReactionsTests (macOS)
+      id: reactions-tests-macos
+      run: |
+        echo "🧪 Running VERAReactionsTests on macOS"
+        xcodebuild test \
+          -workspace VERA/VERA.xcworkspace \
+          -scheme VERAReactionsTests \
+          -destination "platform=macOS" \
+          -derivedDataPath DerivedData \
+          -enableCodeCoverage YES \
+          -resultBundlePath DerivedData/VERAReactionsTests-macOS.xcresult \
+          $XCODE_COMMON_FLAGS | xcpretty
+
     - name: Preboot iOS Simulator
       run: |
         set -euo pipefail
@@ -201,6 +214,31 @@ jobs:
           -derivedDataPath DerivedData \
           -enableCodeCoverage YES \
           -resultBundlePath DerivedData/VERACaptionsSnapshotTests-iOS.xcresult \
+          -parallel-testing-enabled NO \
+          $XCODE_COMMON_FLAGS | xcpretty
+
+    - name: Run VERAReactionsSnapshotTests (iOS Simulator)
+      id: reactions-snapshot-tests
+      timeout-minutes: 15
+      run: |
+        echo "📸 Building VERAReactionsSnapshotTests on iOS Simulator"
+        xcodebuild build-for-testing \
+          -workspace VERA/VERA.xcworkspace \
+          -scheme VERAReactionsSnapshotTests \
+          -destination "platform=iOS Simulator,name=iPhone 17" \
+          -derivedDataPath DerivedData \
+          -enableCodeCoverage YES \
+          -parallel-testing-enabled NO \
+          $XCODE_COMMON_FLAGS | xcpretty
+        
+        echo "📸 Running VERAReactionsSnapshotTests on iOS Simulator"
+        xcodebuild test-without-building \
+          -workspace VERA/VERA.xcworkspace \
+          -scheme VERAReactionsSnapshotTests \
+          -destination "platform=iOS Simulator,name=iPhone 17" \
+          -derivedDataPath DerivedData \
+          -enableCodeCoverage YES \
+          -resultBundlePath DerivedData/VERAReactionsSnapshotTests-iOS.xcresult \
           -parallel-testing-enabled NO \
           $XCODE_COMMON_FLAGS | xcpretty
 
@@ -338,10 +376,12 @@ jobs:
           DerivedData/VERAChatTests-macOS.xcresult
           DerivedData/VERAArchivingTests-macOS.xcresult
           DerivedData/VERADomainTests-macOS.xcresult
+          DerivedData/VERAReactionsTests-macOS.xcresult
           DerivedData/VERAVonageChatPluginTests-macOS.xcresult
           DerivedData/VERAVonageTests-iOS.xcresult
           DerivedData/VERACoreSnapshotTests-iOS.xcresult
           DerivedData/VERACaptionsSnapshotTests-iOS.xcresult
+          DerivedData/VERAReactionsSnapshotTests-iOS.xcresult
           DerivedData/VERAVonageChatPluginTests-iOS.xcresult
           DerivedData/VERATests-iOS.xcresult
           DerivedData/VERAVonageCallKitPluginTests-iOS.xcresult

--- a/VERA/Config/app-config.json
+++ b/VERA/Config/app-config.json
@@ -19,6 +19,7 @@
     "allowChat": true,
     "allowDeviceSelection": true,
     "allowEmojis": true,
+    "allowReactions": true,
     "allowScreenShare": true,
     "defaultLayoutMode": "activespeaker",
     "showParticipantList": true

--- a/VERA/Config/app-config.json
+++ b/VERA/Config/app-config.json
@@ -19,7 +19,6 @@
     "allowChat": true,
     "allowDeviceSelection": true,
     "allowEmojis": true,
-    "allowReactions": true,
     "allowScreenShare": true,
     "defaultLayoutMode": "activespeaker",
     "showParticipantList": true

--- a/VERA/Project.swift
+++ b/VERA/Project.swift
@@ -98,6 +98,25 @@ private func areCaptionsEnabled() -> Bool {
     return meetingRoomSettings["allowCaptions"] as! Bool
 }
 
+/// Returns whether reactions are enabled according to `app-config.json`.
+///
+/// Expects the JSON shape:
+/// ```json
+/// {
+///   "meetingRoomSettings": {
+///     "allowReactions": true
+///   }
+/// }
+/// ```
+///
+/// - Returns: `true` if `meetingRoomSettings.allowReactions` is `true`, else `false`.
+/// - Important: Uses force-casts based on the expected config shape; misconfigured JSON will crash.
+private func areReactionsEnabled() -> Bool {
+    let config = readAppConfig()
+    let meetingRoomSettings = config["meetingRoomSettings"] as! [String: Any]
+    return meetingRoomSettings["allowReactions"] as! Bool
+}
+
 // MARK: - Dynamic Dependencies
 
 /// Builds Swift Package dependencies dynamically based on feature flags.
@@ -154,6 +173,12 @@ private func createDependencies() -> [TargetDependency] {
             .project(target: "VERACaptions", path: "VERACaptions")
         ])
     }
+
+    if areReactionsEnabled() {
+        dependencies.append(contentsOf: [
+            .project(target: "VERAReactions", path: "VERAReactions")
+        ])
+    }
     return dependencies
 }
 
@@ -200,6 +225,12 @@ private func createBuildSettings() -> Settings {
         baseSettings["CAPTIONS_ENABLED"] = "1"
         flags.append("CAPTIONS_ENABLED")
         print("Captions feature enabled in build settings.")
+    }
+
+    if areReactionsEnabled() {
+        baseSettings["REACTIONS_ENABLED"] = "1"
+        flags.append("REACTIONS_ENABLED")
+        print("Reactions feature enabled in build settings.")
     }
 
     if !flags.isEmpty {

--- a/VERA/Project.swift
+++ b/VERA/Project.swift
@@ -98,23 +98,23 @@ private func areCaptionsEnabled() -> Bool {
     return meetingRoomSettings["allowCaptions"] as! Bool
 }
 
-/// Returns whether reactions are enabled according to `app-config.json`.
+/// Returns whether emojis/reactions are enabled according to `app-config.json`.
 ///
 /// Expects the JSON shape:
 /// ```json
 /// {
 ///   "meetingRoomSettings": {
-///     "allowReactions": true
+///     "allowEmojis": true
 ///   }
 /// }
 /// ```
 ///
-/// - Returns: `true` if `meetingRoomSettings.allowReactions` is `true`, else `false`.
+/// - Returns: `true` if `meetingRoomSettings.allowEmojis` is `true`, else `false`.
 /// - Important: Uses force-casts based on the expected config shape; misconfigured JSON will crash.
-private func areReactionsEnabled() -> Bool {
+private func areEmojisEnabled() -> Bool {
     let config = readAppConfig()
     let meetingRoomSettings = config["meetingRoomSettings"] as! [String: Any]
-    return meetingRoomSettings["allowReactions"] as! Bool
+    return meetingRoomSettings["allowEmojis"] as! Bool
 }
 
 // MARK: - Dynamic Dependencies
@@ -174,7 +174,7 @@ private func createDependencies() -> [TargetDependency] {
         ])
     }
 
-    if areReactionsEnabled() {
+    if areEmojisEnabled() {
         dependencies.append(contentsOf: [
             .project(target: "VERAReactions", path: "VERAReactions")
         ])
@@ -227,7 +227,7 @@ private func createBuildSettings() -> Settings {
         print("Captions feature enabled in build settings.")
     }
 
-    if areReactionsEnabled() {
+    if areEmojisEnabled() {
         baseSettings["REACTIONS_ENABLED"] = "1"
         flags.append("REACTIONS_ENABLED")
         print("Reactions feature enabled in build settings.")

--- a/VERA/VERAReactions/Project.swift
+++ b/VERA/VERAReactions/Project.swift
@@ -1,0 +1,89 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project(
+    name: "VERAReactions",
+    packages: [
+        .swiftSnapshotTesting
+    ],
+    targets: [
+        // MARK: - Framework Target
+        .target(
+            name: "VERAReactions",
+            destinations: [.iPhone, .iPad, .mac],
+            product: .framework,
+            bundleId: "com.vonage.VERAReactions",
+            deploymentTargets: DeploymentTargets.multiplatform(iOS: "16.0", macOS: "14.6"),
+            sources: ["VERAReactions/**"],
+            resources: ["VERAReactions/Resources/**"],
+            scripts: [.swiftLint(targetName: "VERAReactions")],
+            dependencies: [],
+            settings: createBaseBuildSettings()
+        ),
+
+        // MARK: - Demo App Target
+        .target(
+            name: "VERAReactionsApp",
+            destinations: [.iPhone, .iPad, .mac],
+            product: .app,
+            bundleId: "com.vonage.VERAReactionsApp",
+            deploymentTargets: DeploymentTargets.multiplatform(iOS: "16.0", macOS: "14.6"),
+            infoPlist: .extendingDefault(
+                with: [
+                    "CFBundleName": "VERAReactionsApp",
+                    "CFBundleDisplayName": "VERAReactionsApp",
+                ].merging(combinedPlistValues()) { _, new in new }),
+            sources: ["VERAReactionsApp/**"],
+            scripts: [.swiftLint(targetName: "VERAReactionsApp")],
+            dependencies: [
+                .target(name: "VERAReactions")
+            ],
+            settings: createBaseBuildSettings()
+        ),
+
+        // MARK: - Unit Tests Target
+        .target(
+            name: "VERAReactionsTests",
+            destinations: [.iPhone, .iPad, .mac],
+            product: .unitTests,
+            bundleId: "com.vonage.VERAReactionsTests",
+            deploymentTargets: DeploymentTargets.multiplatform(iOS: "16.0", macOS: "14.6"),
+            sources: ["VERAReactionsTests/**"],
+            dependencies: [
+                .target(name: "VERAReactions")
+            ],
+            settings: createBaseBuildSettings()
+        ),
+
+        // MARK: - Snapshot Tests Target
+        .target(
+            name: "VERAReactionsSnapshotTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "com.vonage.VERAReactionsSnapshotTests",
+            deploymentTargets: DeploymentTargets.iOS("16.0"),
+            sources: ["VERAReactionsSnapshotTests/**"],
+            dependencies: [
+                .target(name: "VERAReactions"),
+                .swiftSnapshotTesting,
+            ],
+            settings: createBaseBuildSettings()
+        ),
+    ],
+    schemes: [
+        .scheme(
+            name: "VERAReactionsTests",
+            shared: true,
+            buildAction: .buildAction(targets: ["VERAReactionsTests"]),
+            testAction: .targets(["VERAReactionsTests"], configuration: .debug),
+            runAction: .runAction(configuration: .debug)
+        ),
+        .scheme(
+            name: "VERAReactionsSnapshotTests",
+            shared: true,
+            buildAction: .buildAction(targets: ["VERAReactionsSnapshotTests"]),
+            testAction: .targets(["VERAReactionsSnapshotTests"], configuration: .debug),
+            runAction: .runAction(configuration: .debug)
+        ),
+    ]
+)

--- a/VERA/VERAReactions/VERAReactions/Resources/Localizable.xcstrings
+++ b/VERA/VERAReactions/VERAReactions/Resources/Localizable.xcstrings
@@ -1,0 +1,7 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+
+  },
+  "version" : "1.0"
+}

--- a/VERA/VERAReactions/VERAReactions/VERAReactions.swift
+++ b/VERA/VERAReactions/VERAReactions/VERAReactions.swift
@@ -1,0 +1,10 @@
+//
+//  Created by Vonage on 2/9/26.
+//
+
+import Foundation
+
+/// Main entry point for VERAReactions module
+public enum VERAReactions {
+    public static let version = "1.0.0"
+}

--- a/VERA/VERAReactions/VERAReactionsApp/VERAReactionsApp.swift
+++ b/VERA/VERAReactions/VERAReactionsApp/VERAReactionsApp.swift
@@ -1,0 +1,30 @@
+//
+//  Created by Vonage on 2/9/26.
+//
+
+import SwiftUI
+import VERAReactions
+
+@main
+struct VERAReactionsApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Text("VERAReactions Demo")
+                .font(.title)
+            Text("Version: \(VERAReactions.version)")
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/VERA/VERAReactions/VERAReactionsApp/VERAReactionsApp.swift
+++ b/VERA/VERAReactions/VERAReactionsApp/VERAReactionsApp.swift
@@ -1,5 +1,5 @@
 //
-//  Created by Vonage on 2/9/26.
+//  Created by Vonage on 02/09/2026.
 //
 
 import SwiftUI

--- a/VERA/VERAReactions/VERAReactionsSnapshotTests/VERAReactionsSnapshotTests.swift
+++ b/VERA/VERAReactions/VERAReactionsSnapshotTests/VERAReactionsSnapshotTests.swift
@@ -2,10 +2,9 @@
 //  Created by Vonage on 2/9/26.
 //
 
-import XCTest
 import SnapshotTesting
-@testable import VERAReactions
+import Testing
 
-final class VERAReactionsSnapshotTests: XCTestCase {
+struct VERAReactionsSnapshotTests {
     // Add snapshot tests here
 }

--- a/VERA/VERAReactions/VERAReactionsSnapshotTests/VERAReactionsSnapshotTests.swift
+++ b/VERA/VERAReactions/VERAReactionsSnapshotTests/VERAReactionsSnapshotTests.swift
@@ -1,0 +1,11 @@
+//
+//  Created by Vonage on 2/9/26.
+//
+
+import XCTest
+import SnapshotTesting
+@testable import VERAReactions
+
+final class VERAReactionsSnapshotTests: XCTestCase {
+    // Add snapshot tests here
+}

--- a/VERA/VERAReactions/VERAReactionsTests/VERAReactionsTests.swift
+++ b/VERA/VERAReactions/VERAReactionsTests/VERAReactionsTests.swift
@@ -2,11 +2,13 @@
 //  Created by Vonage on 2/9/26.
 //
 
-import XCTest
-@testable import VERAReactions
+import Testing
+import VERAReactions
 
-final class VERAReactionsTests: XCTestCase {
-    func testVersion() {
-        XCTAssertEqual(VERAReactions.version, "1.0.0")
+struct VERAReactionsTests {
+
+    @Test
+    func version() {
+        #expect(VERAReactions.version == "1.0.0")
     }
 }

--- a/VERA/VERAReactions/VERAReactionsTests/VERAReactionsTests.swift
+++ b/VERA/VERAReactions/VERAReactionsTests/VERAReactionsTests.swift
@@ -1,0 +1,12 @@
+//
+//  Created by Vonage on 2/9/26.
+//
+
+import XCTest
+@testable import VERAReactions
+
+final class VERAReactionsTests: XCTestCase {
+    func testVersion() {
+        XCTAssertEqual(VERAReactions.version, "1.0.0")
+    }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,8 +9,8 @@ sonar.projectName=Vonage Video iOS App
 sonar.projectVersion=1.0
 
 # Source code configuration
-sonar.sources=VERA/VERAApp/VERA,VERA/VERACore/VERACore,VERA/VERAVonage/VERAVonage,VERA/VERAChat/VERAChat,VERA/VERAVonageChatPlugin/VERAVonageChatPlugin,VERA/VERACommonUI,VERA/VERAArchiving/VERAArchiving,VERA/VERAVonageArchivingPlugin/VERAVonageArchivingPlugin,VERA/VERADomain/VERADomain,VERA/VERABackgroundEffects/VERABackgroundEffects,VERA/VERACaptions/VERACaptions
-sonar.tests=VERA/VERAApp/VERATests,VERA/VERACore/VERACoreTests,VERA/VERAVonage/VERAVonageTests,VERA/VERAApp/VERAUITests,VERA/VERAChat/VERAChatTests,VERA/VERAVonageChatPlugin/VERAVonageChatPluginTests,VERA/VERAArchiving/VERAArchivingTests,VERA/VERAVonageArchivingPlugin/VERAVonageArchivingPluginTests,VERA/VERADomain/VERADomainTests,VERA/VERABackgroundEffects/VERABackgroundEffectsTests,VERA/VERACaptions/VERACaptionsTests,VERA/VERACaptions/VERACaptionsSnapshotTests
+sonar.sources=VERA/VERAApp/VERA,VERA/VERACore/VERACore,VERA/VERAVonage/VERAVonage,VERA/VERAChat/VERAChat,VERA/VERAVonageChatPlugin/VERAVonageChatPlugin,VERA/VERACommonUI,VERA/VERAArchiving/VERAArchiving,VERA/VERAVonageArchivingPlugin/VERAVonageArchivingPlugin,VERA/VERADomain/VERADomain,VERA/VERABackgroundEffects/VERABackgroundEffects,VERA/VERACaptions/VERACaptions,VERA/VERAReactions/VERAReactions
+sonar.tests=VERA/VERAApp/VERATests,VERA/VERACore/VERACoreTests,VERA/VERAVonage/VERAVonageTests,VERA/VERAApp/VERAUITests,VERA/VERAChat/VERAChatTests,VERA/VERAVonageChatPlugin/VERAVonageChatPluginTests,VERA/VERAArchiving/VERAArchivingTests,VERA/VERAVonageArchivingPlugin/VERAVonageArchivingPluginTests,VERA/VERADomain/VERADomainTests,VERA/VERABackgroundEffects/VERABackgroundEffectsTests,VERA/VERACaptions/VERACaptionsTests,VERA/VERACaptions/VERACaptionsSnapshotTests,VERA/VERAReactions/VERAReactionsTests,VERA/VERAReactions/VERAReactionsSnapshotTests
 
 
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
#### What is this PR doing?
Added VERAReactions module as the foundation for the reactions feature. It includes:

- VERAReactions framework (iOS + macOS)
- VERAReactionsApp demo app for isolated previews
- Unit and snapshot test targets
- REACTIONS_ENABLED feature flag integration
- SonarCloud configuration updates

#### How should this be manually tested?

#### What are the relevant tickets?

[VIDSOL-464](https://jira.vonage.com/browse/VIDSOL-464)


#### Justification for skipping ci, if applied?