### PR TITLE
VIDSOL-553: Bump the VideoSDK to v2.33

### DIFF
--- a/VERA/Tuist/ProjectDescriptionHelpers/Package+Dependencies.swift
+++ b/VERA/Tuist/ProjectDescriptionHelpers/Package+Dependencies.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 extension Package {
     public static let vonageVideoSDK = Package.package(
         url: "https://github.com/Vonage/vonage-video-client-sdk-swift",
-        .upToNextMinor(from: "2.32.1")
+        .upToNextMinor(from: "2.33")
     )
 }
 
@@ -14,7 +14,7 @@ extension TargetDependency {
 extension Package {
     public static let vonageVideoTransformersSDK = Package.package(
         url: "https://github.com/Vonage/vonage-client-sdk-video-transformers",
-        .upToNextMinor(from: "2.32.1")
+        .upToNextMinor(from: "2.33")
     )
 }
 


### PR DESCRIPTION
#### What is this PR doing?
`vonage-video-client-sdk-swift` and `vonage-client-sdk-video-transformers` version bump to v2.33.

#### How should this be manually tested?
Test that the app connects properly to the meetings

#### What are the relevant tickets?

[VIDSOL-553](https://jira.vonage.com/browse/VIDSOL-553)


#### Justification for skipping ci, if applied?