### PR TITLE
Fixed publishing issue on simulator

### DIFF
--- a/VERA/VERAVonageCallKitPlugin/VERAVonageCallKitPlugin/VonageCallKitPlugin.swift
+++ b/VERA/VERAVonageCallKitPlugin/VERAVonageCallKitPlugin/VonageCallKitPlugin.swift
@@ -73,19 +73,17 @@ public final class VonageCallKitPlugin: VonagePlugin, VonagePluginCallHolder {
     /// - Throws: ``VonageCallKitPlugin/Error/invalidCallID`` if `callID` cannot be parsed.
     /// - SeeAlso: ``VonageCallParams``
     public func callDidStart(_ userInfo: [String: Any]) async throws {
-        #if !targetEnvironment(simulator)
-            let roomName = userInfo[VonageCallParams.roomName.rawValue] as? String ?? ""
-            let callID = userInfo[VonageCallParams.callID.rawValue] as? String ?? ""
+        let roomName = userInfo[VonageCallParams.roomName.rawValue] as? String ?? ""
+        let callID = userInfo[VonageCallParams.callID.rawValue] as? String ?? ""
 
-            if let callUUID = UUID(uuidString: callID) {
-                currentCallID = callUUID
-                try await callManager.startCall(handle: roomName, callID: callUUID)
-                providerDelegate?.reportConnected(callUUID: callUUID)
-                providerDelegate?.setupHold(to: callUUID)
-            } else {
-                throw Error.invalidCallID
-            }
-        #endif
+        if let callUUID = UUID(uuidString: callID) {
+            currentCallID = callUUID
+            try await callManager.startCall(handle: roomName, callID: callUUID)
+            providerDelegate?.reportConnected(callUUID: callUUID)
+            providerDelegate?.setupHold(to: callUUID)
+        } else {
+            throw Error.invalidCallID
+        }
     }
 
     /// Lifecycle callback invoked when the call ends and the session is disconnecting.
@@ -96,11 +94,9 @@ public final class VonageCallKitPlugin: VonagePlugin, VonagePluginCallHolder {
     ///
     /// - Throws: An error if `VERACallManager` fails to end the call.
     public func callDidEnd() async throws {
-        #if !targetEnvironment(simulator)
-            guard let currentCallID = currentCallID else { return }
-            self.currentCallID = nil
-            try await callManager.end(callID: currentCallID)
-        #endif
+        guard let currentCallID = currentCallID else { return }
+        self.currentCallID = nil
+        try await callManager.end(callID: currentCallID)
     }
 
     /// Initializes CallKit and audio session components and wires provider events.
@@ -117,34 +113,36 @@ public final class VonageCallKitPlugin: VonagePlugin, VonagePluginCallHolder {
     /// - Important: Must be called before invoking lifecycle methods or handling events.
     /// - Note: End-call events are ignored while on hold to preserve the paused state.
     public func setup() {
+
+        callManager = VERACallManager()
         #if !targetEnvironment(simulator)
-            callManager = VERACallManager()
             sessionManager = OTAudioDeviceManager.currentAudioSessionManager()
             sessionManager?.enableCallingServicesMode()
-            providerDelegate = ProviderDelegate(sessionManager: sessionManager)
-            providerDelegate?.onEndCall = { [weak self] in
-                Task { [weak self] in
-                    guard let self else { return }
-                    if let isOnHold = self.call?.isOnHold, isOnHold {
-                        // Ignore end call event
-                    } else {
-                        self.currentCallID = nil
-                        try? await self.call?.disconnect()
-                    }
-                }
-            }
-            providerDelegate?.onProviderReset = { [weak self] in
-                Task { [weak self] in
-                    self?.currentCallID = nil
-                    try? await self?.call?.disconnect()
-                }
-            }
-            providerDelegate?.onHold = { [weak self] isOnHold in
-                self?.call?.setOnHold(isOnHold)
-            }
-            providerDelegate?.onMute = { [weak self] isMuted in
-                self?.call?.muteLocalMedia(isMuted)
-            }
         #endif
+        providerDelegate = ProviderDelegate(sessionManager: sessionManager)
+        providerDelegate?.onEndCall = { [weak self] in
+            Task { [weak self] in
+                guard let self else { return }
+                if let isOnHold = self.call?.isOnHold, isOnHold {
+                    // Ignore end call event
+                } else {
+                    self.currentCallID = nil
+                    try? await self.call?.disconnect()
+                }
+            }
+        }
+        providerDelegate?.onProviderReset = { [weak self] in
+            Task { [weak self] in
+                self?.currentCallID = nil
+                try? await self?.call?.disconnect()
+            }
+        }
+        providerDelegate?.onHold = { [weak self] isOnHold in
+            self?.call?.setOnHold(isOnHold)
+        }
+        providerDelegate?.onMute = { [weak self] isMuted in
+            self?.call?.muteLocalMedia(isMuted)
+        }
+
     }
 }

--- a/VERA/VERAVonageCallKitPlugin/VERAVonageCallKitPlugin/VonageCallKitPlugin.swift
+++ b/VERA/VERAVonageCallKitPlugin/VERAVonageCallKitPlugin/VonageCallKitPlugin.swift
@@ -24,6 +24,10 @@ import VERAVonage
 /// - SeeAlso: ``VonagePlugin``, ``VonagePluginCallLifeCycle``, ``VonagePluginCallHolder``, ``VonageCallParams``
 /// - Note: The plugin requires a valid `callID` UUID in `userInfo` to drive CallKit.
 ///   If parsing fails, it throws ``VonageCallKitPlugin/Error/invalidCallID``.
+/// - Warning: CallKit is not supported on the iOS Simulator. When the plugin is
+///   active on a Simulator target, `OTPublisher` fails to publish with a connection
+///   timeout. Skip `setup()` or guard with `#if !targetEnvironment(simulator)` when
+///   running on Simulator.
 public final class VonageCallKitPlugin: VonagePlugin, VonagePluginCallHolder {
 
     /// Errors emitted by the CallKit plugin.
@@ -69,6 +73,7 @@ public final class VonageCallKitPlugin: VonagePlugin, VonagePluginCallHolder {
     /// - Throws: ``VonageCallKitPlugin/Error/invalidCallID`` if `callID` cannot be parsed.
     /// - SeeAlso: ``VonageCallParams``
     public func callDidStart(_ userInfo: [String: Any]) async throws {
+        #if !targetEnvironment(simulator)
         let roomName = userInfo[VonageCallParams.roomName.rawValue] as? String ?? ""
         let callID = userInfo[VonageCallParams.callID.rawValue] as? String ?? ""
 
@@ -80,6 +85,7 @@ public final class VonageCallKitPlugin: VonagePlugin, VonagePluginCallHolder {
         } else {
             throw Error.invalidCallID
         }
+        #endif
     }
 
     /// Lifecycle callback invoked when the call ends and the session is disconnecting.
@@ -90,9 +96,11 @@ public final class VonageCallKitPlugin: VonagePlugin, VonagePluginCallHolder {
     ///
     /// - Throws: An error if `VERACallManager` fails to end the call.
     public func callDidEnd() async throws {
+        #if !targetEnvironment(simulator)
         guard let currentCallID = currentCallID else { return }
         self.currentCallID = nil
         try await callManager.end(callID: currentCallID)
+        #endif
     }
 
     /// Initializes CallKit and audio session components and wires provider events.
@@ -109,6 +117,7 @@ public final class VonageCallKitPlugin: VonagePlugin, VonagePluginCallHolder {
     /// - Important: Must be called before invoking lifecycle methods or handling events.
     /// - Note: End-call events are ignored while on hold to preserve the paused state.
     public func setup() {
+        #if !targetEnvironment(simulator)
         callManager = VERACallManager()
         sessionManager = OTAudioDeviceManager.currentAudioSessionManager()
         sessionManager?.enableCallingServicesMode()
@@ -136,5 +145,6 @@ public final class VonageCallKitPlugin: VonagePlugin, VonagePluginCallHolder {
         providerDelegate?.onMute = { [weak self] isMuted in
             self?.call?.muteLocalMedia(isMuted)
         }
+        #endif
     }
 }

--- a/VERA/VERAVonageCallKitPlugin/VERAVonageCallKitPlugin/VonageCallKitPlugin.swift
+++ b/VERA/VERAVonageCallKitPlugin/VERAVonageCallKitPlugin/VonageCallKitPlugin.swift
@@ -74,17 +74,17 @@ public final class VonageCallKitPlugin: VonagePlugin, VonagePluginCallHolder {
     /// - SeeAlso: ``VonageCallParams``
     public func callDidStart(_ userInfo: [String: Any]) async throws {
         #if !targetEnvironment(simulator)
-        let roomName = userInfo[VonageCallParams.roomName.rawValue] as? String ?? ""
-        let callID = userInfo[VonageCallParams.callID.rawValue] as? String ?? ""
+            let roomName = userInfo[VonageCallParams.roomName.rawValue] as? String ?? ""
+            let callID = userInfo[VonageCallParams.callID.rawValue] as? String ?? ""
 
-        if let callUUID = UUID(uuidString: callID) {
-            currentCallID = callUUID
-            try await callManager.startCall(handle: roomName, callID: callUUID)
-            providerDelegate?.reportConnected(callUUID: callUUID)
-            providerDelegate?.setupHold(to: callUUID)
-        } else {
-            throw Error.invalidCallID
-        }
+            if let callUUID = UUID(uuidString: callID) {
+                currentCallID = callUUID
+                try await callManager.startCall(handle: roomName, callID: callUUID)
+                providerDelegate?.reportConnected(callUUID: callUUID)
+                providerDelegate?.setupHold(to: callUUID)
+            } else {
+                throw Error.invalidCallID
+            }
         #endif
     }
 
@@ -97,9 +97,9 @@ public final class VonageCallKitPlugin: VonagePlugin, VonagePluginCallHolder {
     /// - Throws: An error if `VERACallManager` fails to end the call.
     public func callDidEnd() async throws {
         #if !targetEnvironment(simulator)
-        guard let currentCallID = currentCallID else { return }
-        self.currentCallID = nil
-        try await callManager.end(callID: currentCallID)
+            guard let currentCallID = currentCallID else { return }
+            self.currentCallID = nil
+            try await callManager.end(callID: currentCallID)
         #endif
     }
 
@@ -118,33 +118,33 @@ public final class VonageCallKitPlugin: VonagePlugin, VonagePluginCallHolder {
     /// - Note: End-call events are ignored while on hold to preserve the paused state.
     public func setup() {
         #if !targetEnvironment(simulator)
-        callManager = VERACallManager()
-        sessionManager = OTAudioDeviceManager.currentAudioSessionManager()
-        sessionManager?.enableCallingServicesMode()
-        providerDelegate = ProviderDelegate(sessionManager: sessionManager)
-        providerDelegate?.onEndCall = { [weak self] in
-            Task { [weak self] in
-                guard let self else { return }
-                if let isOnHold = self.call?.isOnHold, isOnHold {
-                    // Ignore end call event
-                } else {
-                    self.currentCallID = nil
-                    try? await self.call?.disconnect()
+            callManager = VERACallManager()
+            sessionManager = OTAudioDeviceManager.currentAudioSessionManager()
+            sessionManager?.enableCallingServicesMode()
+            providerDelegate = ProviderDelegate(sessionManager: sessionManager)
+            providerDelegate?.onEndCall = { [weak self] in
+                Task { [weak self] in
+                    guard let self else { return }
+                    if let isOnHold = self.call?.isOnHold, isOnHold {
+                        // Ignore end call event
+                    } else {
+                        self.currentCallID = nil
+                        try? await self.call?.disconnect()
+                    }
                 }
             }
-        }
-        providerDelegate?.onProviderReset = { [weak self] in
-            Task { [weak self] in
-                self?.currentCallID = nil
-                try? await self?.call?.disconnect()
+            providerDelegate?.onProviderReset = { [weak self] in
+                Task { [weak self] in
+                    self?.currentCallID = nil
+                    try? await self?.call?.disconnect()
+                }
             }
-        }
-        providerDelegate?.onHold = { [weak self] isOnHold in
-            self?.call?.setOnHold(isOnHold)
-        }
-        providerDelegate?.onMute = { [weak self] isMuted in
-            self?.call?.muteLocalMedia(isMuted)
-        }
+            providerDelegate?.onHold = { [weak self] isOnHold in
+                self?.call?.setOnHold(isOnHold)
+            }
+            providerDelegate?.onMute = { [weak self] isMuted in
+                self?.call?.muteLocalMedia(isMuted)
+            }
         #endif
     }
 }

--- a/VERA/VERAVonageCallKitPlugin/VERAVonageCallKitPluginTests/VonageCallKitPluginTests.swift
+++ b/VERA/VERAVonageCallKitPlugin/VERAVonageCallKitPluginTests/VonageCallKitPluginTests.swift
@@ -86,14 +86,14 @@ struct VonageCallKitPluginTests {
         #expect(sut.callManager != nil)
     }
 
-    @Test func setupInitializesSessionManager() async {
+    @Test func setupDoesNotInitializeSessionManagerOnSimulator() async {
         let sut = makeSUT()
 
         #expect(sut.sessionManager == nil)
 
         sut.setup()
 
-        #expect(sut.sessionManager != nil)
+        #expect(sut.sessionManager == nil)
     }
 
     @Test func setupInitializesProviderDelegate() async {


### PR DESCRIPTION
#### What is this PR doing?
Fixes a publishing issue on iOS simulator by deactivating CallKit.
Using CallKit makes the publisher publish to session to timeout, so that the video stream can not be seen from other devices/simulators.

#### How should this be manually tested?
Run VERA on a simulator and then check from another device.

#### What are the relevant tickets?

[VIDSOL-633](https://jira.vonage.com/browse/VIDSOL-633)


#### Justification for skipping ci, if applied?