### PR TITLE
VIDSOL-589: Prevents keyboard from hiding text fields

### DIFF
--- a/VERA/VERACore/VERACore/Common/UI/HorizontalContentView.swift
+++ b/VERA/VERACore/VERACore/Common/UI/HorizontalContentView.swift
@@ -15,14 +15,18 @@ struct HorizontalContentView<Left: View, Right: View>: View {
     private let showFooter: Bool
     private let footerHeight: CGFloat = 40
 
+    private let ignoresKeyboard: Bool
+
     init(
         showHeader: Bool = true,
         showFooter: Bool = true,
+        ignoresKeyboard: Bool = true,
         @ViewBuilder leftSide: @escaping () -> Left,
         @ViewBuilder rightSide: @escaping () -> Right
     ) {
         self.showHeader = showHeader
         self.showFooter = showFooter
+        self.ignoresKeyboard = ignoresKeyboard
         self.leftSide = leftSide
         self.rightSide = rightSide
     }
@@ -103,7 +107,7 @@ struct HorizontalContentView<Left: View, Right: View>: View {
             )
         }
         .background(VERACommonUIAsset.SemanticColors.surface.swiftUIColor)
-        .ignoresSafeArea(.keyboard)
+        .if(ignoresKeyboard) { $0.ignoresSafeArea(.keyboard) }
         .if(iOS26Available()) {
             $0.ignoresSafeArea(edges: .top)
         }

--- a/VERA/VERACore/VERACore/Common/UI/VerticalContentView.swift
+++ b/VERA/VERACore/VERACore/Common/UI/VerticalContentView.swift
@@ -9,13 +9,16 @@ struct VerticalContentView<Top: View, Bottom: View>: View {
     private let topSide: () -> Top
     private let bottomSide: () -> Bottom
     private let showLogo: Bool
+    private let ignoresKeyboard: Bool
 
     init(
         showLogo: Bool = true,
+        ignoresKeyboard: Bool = true,
         @ViewBuilder topSide: @escaping () -> Top,
         @ViewBuilder bottomSide: @escaping () -> Bottom
     ) {
         self.showLogo = showLogo
+        self.ignoresKeyboard = ignoresKeyboard
         self.topSide = topSide
         self.bottomSide = bottomSide
     }
@@ -47,7 +50,7 @@ struct VerticalContentView<Top: View, Bottom: View>: View {
             .padding(.horizontal)
         }
         .background(VERACommonUIAsset.SemanticColors.surface.swiftUIColor)
-        .ignoresSafeArea(.keyboard)
+        .if(ignoresKeyboard) { $0.ignoresSafeArea(.keyboard) }
     }
 }
 

--- a/VERA/VERACore/VERACore/Common/UI/ViewCondition.swift
+++ b/VERA/VERACore/VERACore/Common/UI/ViewCondition.swift
@@ -1,0 +1,15 @@
+//
+//  Created by Vonage on 17/3/26.
+//
+
+import SwiftUI
+
+extension View {
+    @ViewBuilder func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}

--- a/VERA/VERACore/VERACore/Landing page/UI/Views/LandingPageView.swift
+++ b/VERA/VERACore/VERACore/Landing page/UI/Views/LandingPageView.swift
@@ -60,7 +60,7 @@ public struct HorizontalLandingContentView: View {
     }
 
     public var body: some View {
-        HorizontalContentView(showFooter: verticalSizeClass == .regular) {
+        HorizontalContentView(showFooter: verticalSizeClass == .regular, ignoresKeyboard: false) {
             LandingPageWelcome()
         } rightSide: {
             CardView {
@@ -88,7 +88,7 @@ public struct VerticalLandingContentView: View {
     }
 
     public var body: some View {
-        VerticalContentView {
+        VerticalContentView(ignoresKeyboard: false) {
             LandingPageWelcome()
                 .padding(.horizontal)
                 .padding()

--- a/VERA/VERACore/VERACore/Meeting room/UI/View/AdaptiveGridLayout.swift
+++ b/VERA/VERACore/VERACore/Meeting room/UI/View/AdaptiveGridLayout.swift
@@ -274,16 +274,6 @@ struct GridLayout {
     }
 }
 
-extension View {
-    @ViewBuilder func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
-    }
-}
-
 #Preview {
     AdaptiveGridLayout(
         participants: [],

--- a/VERA/VERACore/VERACore/Meeting room/UI/View/MeetingRoomView.swift
+++ b/VERA/VERACore/VERACore/Meeting room/UI/View/MeetingRoomView.swift
@@ -28,7 +28,6 @@ public struct MeetingRoomView: View {
     @State private var isBottomBarVisible = true
     @State private var isNavigationBarVisible = true
     @State private var showParticipantsList = false
-    @State private var hideTimer: Timer?
     @State private var urlToShare: URL?
 
     public init(
@@ -56,7 +55,7 @@ public struct MeetingRoomView: View {
                 .animation(.spring(response: 0.6, dampingFraction: 0.8), value: isNavigationBarVisible)
                 .contentShape(Rectangle())
                 .onTapGesture {
-                    showBottomBarAndResetTimer()
+                    toggleBarsVisibility()
                 }
 
                 VStack(alignment: .center) {
@@ -75,7 +74,7 @@ public struct MeetingRoomView: View {
                     .opacity(isBottomBarVisible ? 1.0 : 0.0)
                     .animation(.easeInOut(duration: 0.3), value: isBottomBarVisible)
                     .onTapGesture {
-                        showBottomBarAndResetTimer()
+                        showBars()
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -108,12 +107,6 @@ public struct MeetingRoomView: View {
                 ) {
                     showParticipantsList = false
                 }
-            }
-            .onAppear {
-                startHideTimer()
-            }
-            .onDisappear {
-                cancelHideTimer()
             }
             #if !os(macOS)
                 .toolbar(isNavigationBarVisible ? .visible : .hidden, for: .navigationBar)
@@ -214,34 +207,19 @@ public struct MeetingRoomView: View {
         ProcessInfo.processInfo.isiOSAppOnMac
     }
 
-    // MARK: - Auto-hide Controls Functions
-
-    private func startHideTimer() {
-        cancelHideTimer()
-        hideTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { _ in
-            withAnimation(.easeInOut(duration: 0.6)) {
-                isBottomBarVisible = false
-                isNavigationBarVisible = false
-            }
-        }
+    private func toggleBarsVisibility() {
+        showBars(value: !isBottomBarVisible)
     }
 
-    private func cancelHideTimer() {
-        hideTimer?.invalidate()
-        hideTimer = nil
-    }
-
-    private func showBottomBarAndResetTimer() {
-        cancelHideTimer()
+    private func showBars(value: Bool = true) {
         withAnimation(.easeInOut(duration: 0.4)) {
-            isBottomBarVisible = true
-            isNavigationBarVisible = true
+            isBottomBarVisible = value
+            isNavigationBarVisible = value
         }
-        startHideTimer()
     }
 
     private func onBottomBarInteraction() {
-        showBottomBarAndResetTimer()
+        showBars()
     }
 
     private var wrappedActions: MeetingRoomActions {

--- a/VERA/VERACore/VERACore/Waiting room/UI/Views/WaitingRoomView.swift
+++ b/VERA/VERACore/VERACore/Waiting room/UI/Views/WaitingRoomView.swift
@@ -106,7 +106,7 @@ struct HorizontalWaitingRoomContentView: View {
     let onCameraToggle: () -> Void
 
     var body: some View {
-        HorizontalContentView(showHeader: verticalSizeClass == .regular) {
+        HorizontalContentView(showHeader: verticalSizeClass == .regular, ignoresKeyboard: false) {
             VideoPreviewView(
                 state: state,
                 userName: userName,
@@ -134,7 +134,7 @@ struct VerticalWaitingRoomContentView: View {
     let onCameraToggle: () -> Void
 
     var body: some View {
-        VerticalContentView(showLogo: false) {
+        VerticalContentView(showLogo: false, ignoresKeyboard: false) {
             VideoPreviewView(
                 state: state,
                 userName: userName,
@@ -142,6 +142,7 @@ struct VerticalWaitingRoomContentView: View {
                 onMicrophoneToggle: onMicrophoneToggle,
                 onCameraToggle: onCameraToggle
             )
+            .fixedSize(horizontal: false, vertical: true)
         } bottomSide: {
             PrepareToJoinRoom(
                 state: state,


### PR DESCRIPTION
#### What is this PR doing?
Prevents keyboard from hiding UI components.
Removed auto bar hide timer in meeting room, the top and bottom bars will show and hide based on user taps.

#### How should this be manually tested?
In an iPhone try to see if the UI elements are hidden when keyboard is shown in the landing and waiting views.
The meeting room header and footer won't automatically hide after 5 seconds.

#### What are the relevant tickets?

[VIDSOL-588](https://jira.vonage.com/browse/VIDSOL-588)
[VIDSOL-589](https://jira.vonage.com/browse/VIDSOL-589)

#### Justification for skipping ci, if applied?