### PR TITLE
VIDSOL-516: Add release notes to TestFlight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,8 +590,9 @@ jobs:
   upload-testflight:
     name: Upload to TestFlight
     runs-on: macos-26
-    needs: [unit-tests]
-    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && github.event_name == 'push'
+    #needs: [unit-tests]
+    needs: [format-check]
+    #if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && github.event_name == 'push'
     timeout-minutes: 30
     
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,9 +674,17 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Extract PR number from merge commit message (e.g. "Merge pull request #42 from ...")
+        COMMIT_SHA=$(git rev-parse HEAD)
         COMMIT_MSG=$(git log -1 --pretty=%s)
+
+        # Try to extract PR number from merge commit message (e.g. "Merge pull request #42 from ...")
         PR_NUMBER=$(echo "$COMMIT_MSG" | sed -n 's/.*#\([0-9]*\).*/\1/p')
+
+        # If no PR number in message, query the API for PRs associated with this commit
+        if [ -z "$PR_NUMBER" ]; then
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" \
+            --jq '.[0].number' 2>/dev/null || echo "")
+        fi
 
         if [ -n "$PR_NUMBER" ]; then
           PR_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq '.title' 2>/dev/null || echo "")
@@ -707,7 +715,7 @@ jobs:
         echo "$NOTES"
 
     - name: Upload to TestFlight
-      uses: apple-actions/upload-testflight-build@v4
+      uses: apple-actions/upload-testflight-build@v3
       with:
         app-path: build/VERA.ipa
         issuer-id: ${{ vars.APPSTORE_ISSUER_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,10 +668,48 @@ jobs:
             -allowProvisioningUpdates \
             -exportPath "$PWD/build" | xcpretty
 
+    - name: Generate release notes from PR
+      id: release_notes
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Extract PR number from merge commit message (e.g. "Merge pull request #42 from ...")
+        COMMIT_MSG=$(git log -1 --pretty=%s)
+        PR_NUMBER=$(echo "$COMMIT_MSG" | sed -n 's/.*#\([0-9]*\).*/\1/p')
+
+        if [ -n "$PR_NUMBER" ]; then
+          PR_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq '.title' 2>/dev/null || echo "")
+          PR_BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body' 2>/dev/null || echo "")
+
+          if [ -n "$PR_TITLE" ]; then
+            NOTES="$PR_TITLE"
+            if [ -n "$PR_BODY" ]; then
+              NOTES=$(printf "%s\n\n%s" "$PR_TITLE" "$PR_BODY")
+            fi
+          else
+            NOTES="$COMMIT_MSG"
+          fi
+        else
+          NOTES="$COMMIT_MSG"
+        fi
+
+        # TestFlight "What to Test" has a 4000 char limit
+        NOTES=$(echo "$NOTES" | head -c 4000)
+
+        {
+          echo "whats_new<<RELEASE_NOTES_EOF"
+          echo "$NOTES"
+          echo "RELEASE_NOTES_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "📝 Release notes:"
+        echo "$NOTES"
+
     - name: Upload to TestFlight
-      uses: apple-actions/upload-testflight-build@v3
+      uses: apple-actions/upload-testflight-build@v4
       with:
         app-path: build/VERA.ipa
         issuer-id: ${{ vars.APPSTORE_ISSUER_ID }}
         api-key-id: ${{ vars.APPSTORE_API_KEY_ID }}
         api-private-key: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+        release-notes: ${{ steps.release_notes.outputs.whats_new }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,7 +715,7 @@ jobs:
         echo "$NOTES"
 
     - name: Upload to TestFlight
-      uses: apple-actions/upload-testflight-build@v3
+      uses: apple-actions/upload-testflight-build@v3.0.1
       with:
         app-path: build/VERA.ipa
         issuer-id: ${{ vars.APPSTORE_ISSUER_ID }}

--- a/VERA/VERAVonageScreenSharePlugin/Project.swift
+++ b/VERA/VERAVonageScreenSharePlugin/Project.swift
@@ -47,6 +47,8 @@ let project = Project(
             deploymentTargets: DeploymentTargets.iOS("16.0"),
             infoPlist: .extendingDefault(with: [
                 "CFBundleDisplayName": "VERA Broadcast",
+                "CFBundleShortVersionString": "$(MARKETING_VERSION)",
+                "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
                 "NSExtension": .dictionary([
                     "NSExtensionPointIdentifier": "com.apple.broadcast-services-upload",
                     "NSExtensionPrincipalClass": "$(PRODUCT_MODULE_NAME).BroadcastSampleHandler",


### PR DESCRIPTION
#### What is this PR doing?
When a TestFlight built is generated the job reads the PR title and body to generate automatically the build release notes.

#### How should this be manually tested?
Check in TestFlight that this body is included.

#### What are the relevant tickets?

[VIDSOL-516](https://jira.vonage.com/browse/VIDSOL-516)


#### Justification for skipping ci, if applied?