### PR TITLE
VIDSOL-805: Improve E2E Test Performance – Disable Simulator Animations

### DIFF
--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -82,7 +82,27 @@ jobs:
           xcrun simctl list devices
 
       - name: Run Maestro Tests
-        run: ./scripts/run-maestro-tests.sh
+        run: |
+          mkdir -p test-reports
+
+          xcrun simctl spawn booted log stream \
+            --style compact \
+            --level debug \
+            --predicate 'process == "VERA" OR process == "SpringBoard" OR subsystem CONTAINS "com.apple.frontboard" OR subsystem CONTAINS "com.apple.runningboard"' \
+            > test-reports/simulator-live.log 2>&1 &
+          LOG_PID=$!
+
+          set +e
+          ./scripts/run-maestro-tests.sh
+          TEST_RESULT=$?
+          set -e
+
+          kill "$LOG_PID" 2>/dev/null || true
+
+          xcrun simctl diagnose --output test-reports/simctl-diagnose 2>/dev/null || true
+          cp -R ~/Library/Logs/DiagnosticReports test-reports/DiagnosticReports 2>/dev/null || true
+
+          exit "$TEST_RESULT"
         env:
           BASE_API_URL: ${{ secrets.BASE_API_URL }}
           DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -6,12 +6,6 @@ on:
   push:
     branches: [develop]
   workflow_dispatch:
-    inputs:
-      runner_benchmark:
-        description: 'Run Maestro runner benchmark instead of the full suite'
-        required: false
-        type: boolean
-        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,8 +14,7 @@ concurrency:
 jobs:
   maestro-tests:
     name: Run Maestro UI Tests
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.runner_benchmark != true }}
-    runs-on: macos-26
+    runs-on: macos-26-xlarge
     timeout-minutes: 60
 
     steps:
@@ -182,119 +175,3 @@ jobs:
               repo: context.repo.repo,
               body: comment
             });
-
-  maestro-runner-benchmark:
-    name: Benchmark Maestro on ${{ matrix.os }}
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner_benchmark == true }}
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-15, macos-26, macos-26-arm64]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Pull LFS files
-        run: git lfs pull
-
-      - name: Pre-boot simulator
-        run: xcrun simctl boot "iPhone 17" 2>/dev/null || true
-
-      - name: Print runner diagnostics
-        run: |
-          sw_vers
-          echo ""
-          xcodebuild -version
-          echo ""
-          sysctl -n hw.ncpu | xargs echo "CPU cores:"
-          sysctl -n hw.memsize | awk '{ printf "Memory: %.2f GB\n", $1 / 1024 / 1024 / 1024 }'
-          uptime
-          echo ""
-          echo "Available iOS Simulators:"
-          xcrun simctl list devices available | grep iPhone
-
-      - name: Install Tuist
-        run: brew install tuist
-
-      - name: Install Java 17 (Maestro dependency)
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Install Maestro
-        run: |
-          curl -Ls "https://get.maestro.mobile.dev" | bash
-          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
-
-      - name: Install SwiftLint
-        run: brew install swiftlint
-
-      - name: Export build flags
-        run: |
-          {
-            echo 'XCODE_COMMON_FLAGS=COMPILER_INDEX_STORE_ENABLE=NO ONLY_ACTIVE_ARCH=YES CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO RUN_SWIFTLINT=NO'
-          } >> $GITHUB_ENV
-
-      - name: Generate project with Tuist
-        run: |
-          cd VERA
-          export DEVELOPMENT_TEAM=${{ secrets.DEVELOPMENT_TEAM }}
-          export BASE_API_URL=${{ secrets.BASE_API_URL }}
-          export MARKETING_VERSION=1.1
-          export CURRENT_PROJECT_VERSION=${{ github.run_number }}
-          ./Scripts/generateEnvironmentConstants.sh
-          ./Scripts/regenerateSigningConfig.sh
-          tuist generate --no-open
-          cd ..
-
-      - name: Run Maestro benchmark flows
-        run: |
-          mkdir -p test-reports
-
-          echo "# Maestro runner benchmark (${{ matrix.os }})" | tee test-reports/benchmark-summary.txt
-          echo "Run: ${{ github.run_number }}" | tee -a test-reports/benchmark-summary.txt
-          echo "Commit: ${{ github.sha }}" | tee -a test-reports/benchmark-summary.txt
-          echo "" | tee -a test-reports/benchmark-summary.txt
-
-          set +e
-
-          START=$(date +%s)
-          MAESTRO_LOG_DIR=test-reports ./scripts/run-maestro-tests.sh github-repo-link.yaml 2>&1 | tee test-reports/github-repo-link.log
-          GITHUB_FLOW_RESULT=${PIPESTATUS[0]}
-          END=$(date +%s)
-          echo "github-repo-link: $((END - START))s (exit $GITHUB_FLOW_RESULT)" | tee -a test-reports/benchmark-summary.txt
-
-          START=$(date +%s)
-          MAESTRO_LOG_DIR=test-reports ./scripts/run-maestro-tests.sh waiting-room-controls-enabled.yaml 2>&1 | tee test-reports/waiting-room-controls-enabled.log
-          WAITING_FLOW_RESULT=${PIPESTATUS[0]}
-          END=$(date +%s)
-          echo "waiting-room-controls-enabled: $((END - START))s (exit $WAITING_FLOW_RESULT)" | tee -a test-reports/benchmark-summary.txt
-
-          set -e
-
-          xcrun simctl diagnose --output test-reports/simctl-diagnose 2>/dev/null || true
-          cp -R ~/Library/Logs/DiagnosticReports test-reports/DiagnosticReports 2>/dev/null || true
-
-          if [ "$GITHUB_FLOW_RESULT" -ne 0 ] || [ "$WAITING_FLOW_RESULT" -ne 0 ]; then
-            exit 1
-          fi
-        env:
-          BASE_API_URL: ${{ secrets.BASE_API_URL }}
-          DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
-          MARKETING_VERSION: "1.1"
-          CURRENT_PROJECT_VERSION: ${{ github.run_number }}
-          XCODE_COMMON_FLAGS: ${{ env.XCODE_COMMON_FLAGS }}
-
-      - name: Upload Benchmark Report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: maestro-runner-benchmark-${{ matrix.os }}-${{ github.run_number }}
-          path: test-reports/
-          retention-days: 7
-          if-no-files-found: warn

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches: [develop]
   workflow_dispatch:
+    inputs:
+      runner_benchmark:
+        description: 'Run Maestro runner benchmark instead of the full suite'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,6 +20,7 @@ concurrency:
 jobs:
   maestro-tests:
     name: Run Maestro UI Tests
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.runner_benchmark != true }}
     runs-on: macos-26
     timeout-minutes: 60
 
@@ -175,3 +182,119 @@ jobs:
               repo: context.repo.repo,
               body: comment
             });
+
+  maestro-runner-benchmark:
+    name: Benchmark Maestro on ${{ matrix.os }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.runner_benchmark == true }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15, macos-26, macos-26-arm64]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Pull LFS files
+        run: git lfs pull
+
+      - name: Pre-boot simulator
+        run: xcrun simctl boot "iPhone 17" 2>/dev/null || true
+
+      - name: Print runner diagnostics
+        run: |
+          sw_vers
+          echo ""
+          xcodebuild -version
+          echo ""
+          sysctl -n hw.ncpu | xargs echo "CPU cores:"
+          sysctl -n hw.memsize | awk '{ printf "Memory: %.2f GB\n", $1 / 1024 / 1024 / 1024 }'
+          uptime
+          echo ""
+          echo "Available iOS Simulators:"
+          xcrun simctl list devices available | grep iPhone
+
+      - name: Install Tuist
+        run: brew install tuist
+
+      - name: Install Java 17 (Maestro dependency)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Export build flags
+        run: |
+          {
+            echo 'XCODE_COMMON_FLAGS=COMPILER_INDEX_STORE_ENABLE=NO ONLY_ACTIVE_ARCH=YES CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO RUN_SWIFTLINT=NO'
+          } >> $GITHUB_ENV
+
+      - name: Generate project with Tuist
+        run: |
+          cd VERA
+          export DEVELOPMENT_TEAM=${{ secrets.DEVELOPMENT_TEAM }}
+          export BASE_API_URL=${{ secrets.BASE_API_URL }}
+          export MARKETING_VERSION=1.1
+          export CURRENT_PROJECT_VERSION=${{ github.run_number }}
+          ./Scripts/generateEnvironmentConstants.sh
+          ./Scripts/regenerateSigningConfig.sh
+          tuist generate --no-open
+          cd ..
+
+      - name: Run Maestro benchmark flows
+        run: |
+          mkdir -p test-reports
+
+          echo "# Maestro runner benchmark (${{ matrix.os }})" | tee test-reports/benchmark-summary.txt
+          echo "Run: ${{ github.run_number }}" | tee -a test-reports/benchmark-summary.txt
+          echo "Commit: ${{ github.sha }}" | tee -a test-reports/benchmark-summary.txt
+          echo "" | tee -a test-reports/benchmark-summary.txt
+
+          set +e
+
+          START=$(date +%s)
+          MAESTRO_LOG_DIR=test-reports ./scripts/run-maestro-tests.sh github-repo-link.yaml 2>&1 | tee test-reports/github-repo-link.log
+          GITHUB_FLOW_RESULT=${PIPESTATUS[0]}
+          END=$(date +%s)
+          echo "github-repo-link: $((END - START))s (exit $GITHUB_FLOW_RESULT)" | tee -a test-reports/benchmark-summary.txt
+
+          START=$(date +%s)
+          MAESTRO_LOG_DIR=test-reports ./scripts/run-maestro-tests.sh waiting-room-controls-enabled.yaml 2>&1 | tee test-reports/waiting-room-controls-enabled.log
+          WAITING_FLOW_RESULT=${PIPESTATUS[0]}
+          END=$(date +%s)
+          echo "waiting-room-controls-enabled: $((END - START))s (exit $WAITING_FLOW_RESULT)" | tee -a test-reports/benchmark-summary.txt
+
+          set -e
+
+          xcrun simctl diagnose --output test-reports/simctl-diagnose 2>/dev/null || true
+          cp -R ~/Library/Logs/DiagnosticReports test-reports/DiagnosticReports 2>/dev/null || true
+
+          if [ "$GITHUB_FLOW_RESULT" -ne 0 ] || [ "$WAITING_FLOW_RESULT" -ne 0 ]; then
+            exit 1
+          fi
+        env:
+          BASE_API_URL: ${{ secrets.BASE_API_URL }}
+          DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+          MARKETING_VERSION: "1.1"
+          CURRENT_PROJECT_VERSION: ${{ github.run_number }}
+          XCODE_COMMON_FLAGS: ${{ env.XCODE_COMMON_FLAGS }}
+
+      - name: Upload Benchmark Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-runner-benchmark-${{ matrix.os }}-${{ github.run_number }}
+          path: test-reports/
+          retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -93,8 +93,8 @@ jobs:
           LOG_PID=$!
 
           set +e
-          ./scripts/run-maestro-tests.sh
-          TEST_RESULT=$?
+          ./scripts/run-maestro-tests.sh 2>&1 | tee test-reports/maestro-run.log
+          TEST_RESULT=${PIPESTATUS[0]}
           set -e
 
           kill "$LOG_PID" 2>/dev/null || true

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -7,6 +7,10 @@ on:
     branches: [develop]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   maestro-tests:
     name: Run Maestro UI Tests
@@ -20,6 +24,9 @@ jobs:
       - name: Pull LFS files
         run: git lfs pull
 
+      - name: Pre-boot simulator
+        run: xcrun simctl boot "iPhone 17" 2>/dev/null || true
+
       - name: Print Xcode & Simulator Info
         run: |
           xcodebuild -version
@@ -31,6 +38,7 @@ jobs:
         run: brew install tuist
 
       - name: Clean Tuist cache
+        if: contains(github.event.head_commit.modified, 'VERA/Project.swift') || contains(github.event.head_commit.modified, 'VERA/Workspace.swift') || contains(github.event.head_commit.modified, 'Package.resolved')
         run: |
           echo "🧹 Cleaning Tuist cache to avoid cross-branch contamination"
           tuist clean

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -85,19 +85,10 @@ jobs:
         run: |
           mkdir -p test-reports
 
-          xcrun simctl spawn booted log stream \
-            --style compact \
-            --level debug \
-            --predicate 'process == "VERA" OR process == "SpringBoard" OR subsystem CONTAINS "com.apple.frontboard" OR subsystem CONTAINS "com.apple.runningboard"' \
-            > test-reports/simulator-live.log 2>&1 &
-          LOG_PID=$!
-
           set +e
-          ./scripts/run-maestro-tests.sh 2>&1 | tee test-reports/maestro-run.log
+          MAESTRO_LOG_DIR=test-reports ./scripts/run-maestro-tests.sh 2>&1 | tee test-reports/maestro-run.log
           TEST_RESULT=${PIPESTATUS[0]}
           set -e
-
-          kill "$LOG_PID" 2>/dev/null || true
 
           xcrun simctl diagnose --output test-reports/simctl-diagnose 2>/dev/null || true
           cp -R ~/Library/Logs/DiagnosticReports test-reports/DiagnosticReports 2>/dev/null || true

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,4 +1,3 @@
-appId: com.vonage.VERA
 executionOrder:
   continueOnFailure: true
   flowsOrder:

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,1 +1,4 @@
 appId: com.vonage.VERA
+platform:
+  ios:
+    disableAnimations: true

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,4 +1,15 @@
 appId: com.vonage.VERA
+executionOrder:
+  continueOnFailure: true
+  flowsOrder:
+    - join-with-camera-mic-allowed
+    - create-new-room
+    - waiting-room-controls-disabled
+    - waiting-room-controls-enabled
+    - goodbye-view-landing-page
+    - goodbye-reenter-room
+    - recording
+    - github-repo-link
 platform:
   ios:
     disableAnimations: true

--- a/.maestro/flows/create-new-room.yaml
+++ b/.maestro/flows/create-new-room.yaml
@@ -36,6 +36,6 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 30000
+    timeout: 60000
 
 - takeScreenshot: 02-meeting-room

--- a/.maestro/flows/create-new-room.yaml
+++ b/.maestro/flows/create-new-room.yaml
@@ -6,7 +6,7 @@ appId: ${APP_ID}
       microphone: allow
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "landing-screen"
@@ -19,7 +19,7 @@ appId: ${APP_ID}
     id: "create-new-room-button"
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "waiting-room-screen"
@@ -36,7 +36,7 @@ appId: ${APP_ID}
     id: "join-meeting-button"
 
 - waitForAnimationToEnd:
-    timeout: 10000
+    timeout: 15000
 
 - assertVisible:
     id: "meeting-room-screen"

--- a/.maestro/flows/create-new-room.yaml
+++ b/.maestro/flows/create-new-room.yaml
@@ -36,6 +36,6 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 15000
+    timeout: 30000
 
 - takeScreenshot: 02-meeting-room

--- a/.maestro/flows/create-new-room.yaml
+++ b/.maestro/flows/create-new-room.yaml
@@ -30,6 +30,9 @@ appId: ${APP_ID}
 
 - inputText: "Test User"
 
+- waitForAnimationToEnd:
+    timeout: 2000
+
 - tapOn:
     id: "join-meeting-button"
 

--- a/.maestro/flows/create-new-room.yaml
+++ b/.maestro/flows/create-new-room.yaml
@@ -33,11 +33,16 @@ appId: ${APP_ID}
 
 - inputText: "Test User"
 
+- tapOn:
+    id: "waiting-room-screen"
+    point: "50%,55%"
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 - tapOn:
     id: "join-meeting-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/create-new-room.yaml
+++ b/.maestro/flows/create-new-room.yaml
@@ -1,6 +1,7 @@
 appId: ${APP_ID}
 ---
 - launchApp:
+    clearState: true
     permissions:
       camera: allow
       microphone: allow
@@ -27,6 +28,8 @@ appId: ${APP_ID}
 # Enter username and join meeting
 - tapOn:
     id: "username-input"
+
+- eraseText
 
 - inputText: "Test User"
 

--- a/.maestro/flows/create-new-room.yaml
+++ b/.maestro/flows/create-new-room.yaml
@@ -5,11 +5,10 @@ appId: ${APP_ID}
       camera: allow
       microphone: allow
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "landing-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "landing-screen"
 
 - assertVisible:
     id: "create-new-room-button"
@@ -18,11 +17,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "create-new-room-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "waiting-room-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "waiting-room-screen"
 
 - takeScreenshot: 01-waiting-room-new-room
 
@@ -35,10 +33,9 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-meeting-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "meeting-room-screen"
     timeout: 15000
-
-- assertVisible:
-    id: "meeting-room-screen"
 
 - takeScreenshot: 02-meeting-room

--- a/.maestro/flows/github-repo-link.yaml
+++ b/.maestro/flows/github-repo-link.yaml
@@ -3,7 +3,7 @@ appId: ${APP_ID}
 - launchApp
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "landing-screen"

--- a/.maestro/flows/github-repo-link.yaml
+++ b/.maestro/flows/github-repo-link.yaml
@@ -2,11 +2,10 @@ appId: ${APP_ID}
 ---
 - launchApp
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "landing-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "landing-screen"
 
 # Verify GitHub button is visible
 - assertVisible:

--- a/.maestro/flows/github-repo-link.yaml
+++ b/.maestro/flows/github-repo-link.yaml
@@ -1,6 +1,7 @@
 appId: ${APP_ID}
 ---
-- launchApp
+- launchApp:
+    clearState: true
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/goodbye-reenter-room.yaml
+++ b/.maestro/flows/goodbye-reenter-room.yaml
@@ -36,7 +36,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 15000
+    timeout: 30000
 
 - takeScreenshot: 01-meeting-room
 
@@ -47,7 +47,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "goodbye-screen"
-    timeout: 15000
+    timeout: 20000
 
 # Verify goodbye screen and both buttons
 
@@ -77,6 +77,6 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 20000
+    timeout: 30000
 
 - takeScreenshot: 04-reenter-meeting-room

--- a/.maestro/flows/goodbye-reenter-room.yaml
+++ b/.maestro/flows/goodbye-reenter-room.yaml
@@ -5,11 +5,10 @@ appId: ${APP_ID}
       camera: allow
       microphone: allow
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "landing-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "landing-screen"
 
 # Enter a room name
 - tapOn:
@@ -20,11 +19,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-waiting-room-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "waiting-room-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "waiting-room-screen"
 
 # Enter username and join meeting
 - tapOn:
@@ -35,11 +33,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-meeting-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "meeting-room-screen"
     timeout: 15000
-
-- assertVisible:
-    id: "meeting-room-screen"
 
 - takeScreenshot: 01-meeting-room
 
@@ -47,12 +44,12 @@ appId: ${APP_ID}
 - tapOn:
     id: "meeting-room-end-call-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "goodbye-screen"
     timeout: 15000
 
 # Verify goodbye screen and both buttons
-- assertVisible:
-    id: "goodbye-screen"
 
 - assertVisible:
     id: "goodbye-reenter-button"
@@ -66,11 +63,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "goodbye-reenter-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "waiting-room-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "waiting-room-screen"
 
 - takeScreenshot: 03-reenter-waiting-room
 
@@ -78,10 +74,9 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-meeting-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "meeting-room-screen"
     timeout: 20000
-
-- assertVisible:
-    id: "meeting-room-screen"
 
 - takeScreenshot: 04-reenter-meeting-room

--- a/.maestro/flows/goodbye-reenter-room.yaml
+++ b/.maestro/flows/goodbye-reenter-room.yaml
@@ -16,6 +16,9 @@ appId: ${APP_ID}
 
 - inputText: "testroom"
 
+- waitForAnimationToEnd:
+    timeout: 2000
+
 - tapOn:
     id: "join-waiting-room-button"
 
@@ -29,6 +32,9 @@ appId: ${APP_ID}
     id: "username-input"
 
 - inputText: "Test User"
+
+- waitForAnimationToEnd:
+    timeout: 2000
 
 - tapOn:
     id: "join-meeting-button"

--- a/.maestro/flows/goodbye-reenter-room.yaml
+++ b/.maestro/flows/goodbye-reenter-room.yaml
@@ -36,7 +36,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 30000
+    timeout: 60000
 
 - takeScreenshot: 01-meeting-room
 
@@ -77,6 +77,6 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 30000
+    timeout: 60000
 
 - takeScreenshot: 04-reenter-meeting-room

--- a/.maestro/flows/goodbye-reenter-room.yaml
+++ b/.maestro/flows/goodbye-reenter-room.yaml
@@ -1,6 +1,7 @@
 appId: ${APP_ID}
 ---
 - launchApp:
+    clearState: true
     permissions:
       camera: allow
       microphone: allow
@@ -13,6 +14,8 @@ appId: ${APP_ID}
 # Enter a room name
 - tapOn:
     id: "room-name-input"
+
+- eraseText
 
 - inputText: "testroom"
 
@@ -30,6 +33,8 @@ appId: ${APP_ID}
 # Enter username and join meeting
 - tapOn:
     id: "username-input"
+
+- eraseText
 
 - inputText: "Test User"
 
@@ -49,6 +54,13 @@ appId: ${APP_ID}
 # End the call (async disconnect + fullScreenCover dismiss animation)
 - tapOn:
     id: "meeting-room-end-call-button"
+
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- tapOn:
+    id: "meeting-room-end-call-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/goodbye-reenter-room.yaml
+++ b/.maestro/flows/goodbye-reenter-room.yaml
@@ -6,7 +6,7 @@ appId: ${APP_ID}
       microphone: allow
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "landing-screen"
@@ -21,7 +21,7 @@ appId: ${APP_ID}
     id: "join-waiting-room-button"
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "waiting-room-screen"
@@ -36,7 +36,7 @@ appId: ${APP_ID}
     id: "join-meeting-button"
 
 - waitForAnimationToEnd:
-    timeout: 10000
+    timeout: 15000
 
 - assertVisible:
     id: "meeting-room-screen"
@@ -79,7 +79,7 @@ appId: ${APP_ID}
     id: "join-meeting-button"
 
 - waitForAnimationToEnd:
-    timeout: 10000
+    timeout: 20000
 
 - assertVisible:
     id: "meeting-room-screen"

--- a/.maestro/flows/goodbye-reenter-room.yaml
+++ b/.maestro/flows/goodbye-reenter-room.yaml
@@ -19,11 +19,14 @@ appId: ${APP_ID}
 
 - inputText: "testroom"
 
+- hideKeyboard
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 - tapOn:
     id: "join-waiting-room-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:
@@ -38,11 +41,16 @@ appId: ${APP_ID}
 
 - inputText: "Test User"
 
+- tapOn:
+    id: "waiting-room-screen"
+    point: "50%,55%"
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 - tapOn:
     id: "join-meeting-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:
@@ -91,6 +99,7 @@ appId: ${APP_ID}
 # Rejoin the meeting from waiting room
 - tapOn:
     id: "join-meeting-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/goodbye-view-landing-page.yaml
+++ b/.maestro/flows/goodbye-view-landing-page.yaml
@@ -16,6 +16,9 @@ appId: ${APP_ID}
 
 - inputText: "testroom"
 
+- waitForAnimationToEnd:
+    timeout: 2000
+
 - tapOn:
     id: "join-waiting-room-button"
 
@@ -29,6 +32,9 @@ appId: ${APP_ID}
     id: "username-input"
 
 - inputText: "Test User"
+
+- waitForAnimationToEnd:
+    timeout: 2000
 
 - tapOn:
     id: "join-meeting-button"

--- a/.maestro/flows/goodbye-view-landing-page.yaml
+++ b/.maestro/flows/goodbye-view-landing-page.yaml
@@ -1,6 +1,7 @@
 appId: ${APP_ID}
 ---
 - launchApp:
+    clearState: true
     permissions:
       camera: allow
       microphone: allow
@@ -13,6 +14,8 @@ appId: ${APP_ID}
 # Enter a room name
 - tapOn:
     id: "room-name-input"
+
+- eraseText
 
 - inputText: "testroom"
 
@@ -30,6 +33,8 @@ appId: ${APP_ID}
 # Enter username and join meeting
 - tapOn:
     id: "username-input"
+
+- eraseText
 
 - inputText: "Test User"
 
@@ -49,6 +54,13 @@ appId: ${APP_ID}
 # End the call (async disconnect + fullScreenCover dismiss animation)
 - tapOn:
     id: "meeting-room-end-call-button"
+
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- tapOn:
+    id: "meeting-room-end-call-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/goodbye-view-landing-page.yaml
+++ b/.maestro/flows/goodbye-view-landing-page.yaml
@@ -5,11 +5,10 @@ appId: ${APP_ID}
       camera: allow
       microphone: allow
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "landing-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "landing-screen"
 
 # Enter a room name
 - tapOn:
@@ -20,11 +19,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-waiting-room-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "waiting-room-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "waiting-room-screen"
 
 # Enter username and join meeting
 - tapOn:
@@ -35,11 +33,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-meeting-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "meeting-room-screen"
     timeout: 15000
-
-- assertVisible:
-    id: "meeting-room-screen"
 
 - takeScreenshot: 01-meeting-room
 
@@ -47,12 +44,12 @@ appId: ${APP_ID}
 - tapOn:
     id: "meeting-room-end-call-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "goodbye-screen"
     timeout: 15000
 
 # Verify goodbye screen and both buttons
-- assertVisible:
-    id: "goodbye-screen"
 
 - assertVisible:
     id: "goodbye-reenter-button"
@@ -66,10 +63,9 @@ appId: ${APP_ID}
 - tapOn:
     id: "goodbye-landing-page-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "landing-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "landing-screen"
 
 - takeScreenshot: 03-back-to-landing

--- a/.maestro/flows/goodbye-view-landing-page.yaml
+++ b/.maestro/flows/goodbye-view-landing-page.yaml
@@ -6,7 +6,7 @@ appId: ${APP_ID}
       microphone: allow
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "landing-screen"
@@ -21,7 +21,7 @@ appId: ${APP_ID}
     id: "join-waiting-room-button"
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "waiting-room-screen"
@@ -36,7 +36,7 @@ appId: ${APP_ID}
     id: "join-meeting-button"
 
 - waitForAnimationToEnd:
-    timeout: 10000
+    timeout: 15000
 
 - assertVisible:
     id: "meeting-room-screen"
@@ -67,7 +67,7 @@ appId: ${APP_ID}
     id: "goodbye-landing-page-button"
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "landing-screen"

--- a/.maestro/flows/goodbye-view-landing-page.yaml
+++ b/.maestro/flows/goodbye-view-landing-page.yaml
@@ -36,7 +36,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 15000
+    timeout: 30000
 
 - takeScreenshot: 01-meeting-room
 
@@ -47,7 +47,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "goodbye-screen"
-    timeout: 15000
+    timeout: 20000
 
 # Verify goodbye screen and both buttons
 

--- a/.maestro/flows/goodbye-view-landing-page.yaml
+++ b/.maestro/flows/goodbye-view-landing-page.yaml
@@ -19,11 +19,14 @@ appId: ${APP_ID}
 
 - inputText: "testroom"
 
+- hideKeyboard
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 - tapOn:
     id: "join-waiting-room-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:
@@ -38,11 +41,16 @@ appId: ${APP_ID}
 
 - inputText: "Test User"
 
+- tapOn:
+    id: "waiting-room-screen"
+    point: "50%,55%"
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 - tapOn:
     id: "join-meeting-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/goodbye-view-landing-page.yaml
+++ b/.maestro/flows/goodbye-view-landing-page.yaml
@@ -36,7 +36,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 30000
+    timeout: 60000
 
 - takeScreenshot: 01-meeting-room
 

--- a/.maestro/flows/join-with-camera-mic-allowed.yaml
+++ b/.maestro/flows/join-with-camera-mic-allowed.yaml
@@ -1,6 +1,7 @@
 appId: ${APP_ID}
 ---
 - launchApp:
+    clearState: true
     permissions:
       camera: allow
       microphone: allow
@@ -15,6 +16,8 @@ appId: ${APP_ID}
 # Enter a room name in the text field
 - tapOn:
     id: "room-name-input"
+
+- eraseText
 
 - inputText: "testroom"
 
@@ -35,6 +38,8 @@ appId: ${APP_ID}
 # Enter username
 - tapOn:
     id: "username-input"
+
+- eraseText
 
 - inputText: "Test User"
 

--- a/.maestro/flows/join-with-camera-mic-allowed.yaml
+++ b/.maestro/flows/join-with-camera-mic-allowed.yaml
@@ -18,6 +18,9 @@ appId: ${APP_ID}
 
 - inputText: "testroom"
 
+- waitForAnimationToEnd:
+    timeout: 2000
+
 # Navigate to the waiting room
 - tapOn:
     id: "join-waiting-room-button"
@@ -34,6 +37,9 @@ appId: ${APP_ID}
     id: "username-input"
 
 - inputText: "Test User"
+
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Join the meeting
 - tapOn:

--- a/.maestro/flows/join-with-camera-mic-allowed.yaml
+++ b/.maestro/flows/join-with-camera-mic-allowed.yaml
@@ -21,12 +21,15 @@ appId: ${APP_ID}
 
 - inputText: "testroom"
 
+- hideKeyboard
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 # Navigate to the waiting room
 - tapOn:
     id: "join-waiting-room-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:
@@ -43,12 +46,17 @@ appId: ${APP_ID}
 
 - inputText: "Test User"
 
+- tapOn:
+    id: "waiting-room-screen"
+    point: "50%,55%"
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 # Join the meeting
 - tapOn:
     id: "join-meeting-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/join-with-camera-mic-allowed.yaml
+++ b/.maestro/flows/join-with-camera-mic-allowed.yaml
@@ -42,6 +42,6 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 15000
+    timeout: 30000
 
 - takeScreenshot: 03-meeting-room-joined

--- a/.maestro/flows/join-with-camera-mic-allowed.yaml
+++ b/.maestro/flows/join-with-camera-mic-allowed.yaml
@@ -6,7 +6,7 @@ appId: ${APP_ID}
       microphone: allow
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "landing-screen"
@@ -24,7 +24,7 @@ appId: ${APP_ID}
     id: "join-waiting-room-button"
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "waiting-room-screen"
@@ -42,7 +42,7 @@ appId: ${APP_ID}
     id: "join-meeting-button"
 
 - waitForAnimationToEnd:
-    timeout: 10000
+    timeout: 15000
 
 - assertVisible:
     id: "meeting-room-screen"

--- a/.maestro/flows/join-with-camera-mic-allowed.yaml
+++ b/.maestro/flows/join-with-camera-mic-allowed.yaml
@@ -42,6 +42,6 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 30000
+    timeout: 60000
 
 - takeScreenshot: 03-meeting-room-joined

--- a/.maestro/flows/join-with-camera-mic-allowed.yaml
+++ b/.maestro/flows/join-with-camera-mic-allowed.yaml
@@ -5,11 +5,10 @@ appId: ${APP_ID}
       camera: allow
       microphone: allow
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "landing-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "landing-screen"
 
 - takeScreenshot: 01-landing-screen
 
@@ -23,11 +22,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-waiting-room-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "waiting-room-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "waiting-room-screen"
 
 - takeScreenshot: 02-waiting-room-permissions-granted
 
@@ -41,10 +39,9 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-meeting-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "meeting-room-screen"
     timeout: 15000
-
-- assertVisible:
-    id: "meeting-room-screen"
 
 - takeScreenshot: 03-meeting-room-joined

--- a/.maestro/flows/recording.yaml
+++ b/.maestro/flows/recording.yaml
@@ -19,11 +19,14 @@ appId: ${APP_ID}
 
 - inputText: "testroom"
 
+- hideKeyboard
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 - tapOn:
     id: "join-waiting-room-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:
@@ -45,11 +48,16 @@ appId: ${APP_ID}
 
 - inputText: "Test User"
 
+- tapOn:
+    id: "waiting-room-screen"
+    point: "50%,55%"
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 - tapOn:
     id: "join-meeting-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/recording.yaml
+++ b/.maestro/flows/recording.yaml
@@ -43,7 +43,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 30000
+    timeout: 60000
 
 - takeScreenshot: 01-meeting-room
 

--- a/.maestro/flows/recording.yaml
+++ b/.maestro/flows/recording.yaml
@@ -16,6 +16,9 @@ appId: ${APP_ID}
 
 - inputText: "testroom"
 
+- waitForAnimationToEnd:
+    timeout: 2000
+
 - tapOn:
     id: "join-waiting-room-button"
 
@@ -36,6 +39,9 @@ appId: ${APP_ID}
     id: "username-input"
 
 - inputText: "Test User"
+
+- waitForAnimationToEnd:
+    timeout: 2000
 
 - tapOn:
     id: "join-meeting-button"

--- a/.maestro/flows/recording.yaml
+++ b/.maestro/flows/recording.yaml
@@ -43,7 +43,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 15000
+    timeout: 30000
 
 - takeScreenshot: 01-meeting-room
 
@@ -102,7 +102,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "goodbye-screen"
-    timeout: 15000
+    timeout: 20000
 
 # Verify archive list is visible on goodbye page
 - assertVisible:

--- a/.maestro/flows/recording.yaml
+++ b/.maestro/flows/recording.yaml
@@ -52,7 +52,8 @@ appId: ${APP_ID}
     text: "More options"
     optional: true
 
-- tapOn: "Start Recording"
+- tapOn:
+    id: "archiving-start-recording-button"
 
 - waitForAnimationToEnd:
     timeout: 8000
@@ -78,7 +79,8 @@ appId: ${APP_ID}
     text: "More options"
     optional: true
 
-- tapOn: "Stop Recording"
+- tapOn:
+    id: "archiving-stop-recording-button"
 
 - waitForAnimationToEnd:
     timeout: 8000

--- a/.maestro/flows/recording.yaml
+++ b/.maestro/flows/recording.yaml
@@ -6,7 +6,7 @@ appId: ${APP_ID}
       microphone: allow
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "landing-screen"
@@ -21,7 +21,7 @@ appId: ${APP_ID}
     id: "join-waiting-room-button"
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "waiting-room-screen"
@@ -31,7 +31,7 @@ appId: ${APP_ID}
     id: "waiting-room-mic-enabled"
 
 - waitForAnimationToEnd:
-    timeout: 2000
+    timeout: 3000
 
 # Enter username and join meeting
 - tapOn:
@@ -43,7 +43,7 @@ appId: ${APP_ID}
     id: "join-meeting-button"
 
 - waitForAnimationToEnd:
-    timeout: 10000
+    timeout: 15000
 
 - assertVisible:
     id: "meeting-room-screen"
@@ -58,13 +58,13 @@ appId: ${APP_ID}
 - tapOn: "Start Recording"
 
 - waitForAnimationToEnd:
-    timeout: 3000
+    timeout: 8000
 
 # Confirm start recording alert
 - tapOn: "OK"
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 15000
 
 # Verify recording indicator is visible
 - assertVisible:
@@ -74,7 +74,7 @@ appId: ${APP_ID}
 
 # Wait for recording to accumulate content
 - waitForAnimationToEnd:
-    timeout: 3000
+    timeout: 5000
 
 # Stop recording (button may be in overflow menu on smaller screens)
 - tapOn:
@@ -84,13 +84,13 @@ appId: ${APP_ID}
 - tapOn: "Stop Recording"
 
 - waitForAnimationToEnd:
-    timeout: 3000
+    timeout: 8000
 
 # Confirm stop recording alert
 - tapOn: "OK"
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 # Verify recording indicator is gone
 - assertNotVisible:

--- a/.maestro/flows/recording.yaml
+++ b/.maestro/flows/recording.yaml
@@ -5,11 +5,10 @@ appId: ${APP_ID}
       camera: allow
       microphone: allow
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "landing-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "landing-screen"
 
 # Enter a room name
 - tapOn:
@@ -20,11 +19,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-waiting-room-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "waiting-room-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "waiting-room-screen"
 
 # Disable mic (match React spec: audio off)
 - tapOn:
@@ -42,11 +40,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-meeting-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "meeting-room-screen"
     timeout: 15000
-
-- assertVisible:
-    id: "meeting-room-screen"
 
 - takeScreenshot: 01-meeting-room
 
@@ -63,12 +60,12 @@ appId: ${APP_ID}
 # Confirm start recording alert
 - tapOn: "OK"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "archiving-recording-indicator"
     timeout: 15000
 
 # Verify recording indicator is visible
-- assertVisible:
-    id: "archiving-recording-indicator"
 
 - takeScreenshot: 02-recording-in-progress
 
@@ -89,12 +86,12 @@ appId: ${APP_ID}
 # Confirm stop recording alert
 - tapOn: "OK"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    notVisible:
+      id: "archiving-recording-indicator"
     timeout: 10000
 
 # Verify recording indicator is gone
-- assertNotVisible:
-    id: "archiving-recording-indicator"
 
 - takeScreenshot: 03-recording-stopped
 
@@ -102,11 +99,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "meeting-room-end-call-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "goodbye-screen"
     timeout: 15000
-
-- assertVisible:
-    id: "goodbye-screen"
 
 # Verify archive list is visible on goodbye page
 - assertVisible:

--- a/.maestro/flows/recording.yaml
+++ b/.maestro/flows/recording.yaml
@@ -1,6 +1,7 @@
 appId: ${APP_ID}
 ---
 - launchApp:
+    clearState: true
     permissions:
       camera: allow
       microphone: allow
@@ -13,6 +14,8 @@ appId: ${APP_ID}
 # Enter a room name
 - tapOn:
     id: "room-name-input"
+
+- eraseText
 
 - inputText: "testroom"
 
@@ -37,6 +40,8 @@ appId: ${APP_ID}
 # Enter username and join meeting
 - tapOn:
     id: "username-input"
+
+- eraseText
 
 - inputText: "Test User"
 
@@ -106,6 +111,13 @@ appId: ${APP_ID}
 # End call
 - tapOn:
     id: "meeting-room-end-call-button"
+
+- waitForAnimationToEnd:
+    timeout: 2000
+
+- tapOn:
+    id: "meeting-room-end-call-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/waiting-room-controls-disabled.yaml
+++ b/.maestro/flows/waiting-room-controls-disabled.yaml
@@ -5,11 +5,10 @@ appId: ${APP_ID}
       camera: allow
       microphone: allow
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "landing-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "landing-screen"
 
 # Enter a room name
 - tapOn:
@@ -20,11 +19,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-waiting-room-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "waiting-room-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "waiting-room-screen"
 
 # Verify mic and camera are enabled initially
 - assertVisible:
@@ -64,11 +62,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-meeting-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "meeting-room-screen"
     timeout: 15000
-
-- assertVisible:
-    id: "meeting-room-screen"
 
 # Verify mic and camera remain disabled in meeting room
 - assertVisible:

--- a/.maestro/flows/waiting-room-controls-disabled.yaml
+++ b/.maestro/flows/waiting-room-controls-disabled.yaml
@@ -16,6 +16,9 @@ appId: ${APP_ID}
 
 - inputText: "testroom"
 
+- waitForAnimationToEnd:
+    timeout: 2000
+
 - tapOn:
     id: "join-waiting-room-button"
 
@@ -58,6 +61,9 @@ appId: ${APP_ID}
     id: "username-input"
 
 - inputText: "Test User"
+
+- waitForAnimationToEnd:
+    timeout: 2000
 
 - tapOn:
     id: "join-meeting-button"

--- a/.maestro/flows/waiting-room-controls-disabled.yaml
+++ b/.maestro/flows/waiting-room-controls-disabled.yaml
@@ -1,6 +1,7 @@
 appId: ${APP_ID}
 ---
 - launchApp:
+    clearState: true
     permissions:
       camera: allow
       microphone: allow
@@ -13,6 +14,8 @@ appId: ${APP_ID}
 # Enter a room name
 - tapOn:
     id: "room-name-input"
+
+- eraseText
 
 - inputText: "testroom"
 
@@ -59,6 +62,8 @@ appId: ${APP_ID}
 # Enter username and join meeting
 - tapOn:
     id: "username-input"
+
+- eraseText
 
 - inputText: "Test User"
 

--- a/.maestro/flows/waiting-room-controls-disabled.yaml
+++ b/.maestro/flows/waiting-room-controls-disabled.yaml
@@ -19,11 +19,14 @@ appId: ${APP_ID}
 
 - inputText: "testroom"
 
+- hideKeyboard
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 - tapOn:
     id: "join-waiting-room-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:
@@ -67,11 +70,16 @@ appId: ${APP_ID}
 
 - inputText: "Test User"
 
+- tapOn:
+    id: "waiting-room-screen"
+    point: "50%,55%"
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 - tapOn:
     id: "join-meeting-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/waiting-room-controls-disabled.yaml
+++ b/.maestro/flows/waiting-room-controls-disabled.yaml
@@ -6,7 +6,7 @@ appId: ${APP_ID}
       microphone: allow
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "landing-screen"
@@ -21,7 +21,7 @@ appId: ${APP_ID}
     id: "join-waiting-room-button"
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "waiting-room-screen"
@@ -38,7 +38,7 @@ appId: ${APP_ID}
     id: "waiting-room-mic-enabled"
 
 - waitForAnimationToEnd:
-    timeout: 2000
+    timeout: 3000
 
 - assertVisible:
     id: "waiting-room-mic-disabled"
@@ -48,7 +48,7 @@ appId: ${APP_ID}
     id: "waiting-room-camera-enabled"
 
 - waitForAnimationToEnd:
-    timeout: 2000
+    timeout: 3000
 
 - assertVisible:
     id: "waiting-room-camera-disabled"
@@ -65,7 +65,7 @@ appId: ${APP_ID}
     id: "join-meeting-button"
 
 - waitForAnimationToEnd:
-    timeout: 10000
+    timeout: 15000
 
 - assertVisible:
     id: "meeting-room-screen"

--- a/.maestro/flows/waiting-room-controls-disabled.yaml
+++ b/.maestro/flows/waiting-room-controls-disabled.yaml
@@ -65,7 +65,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 30000
+    timeout: 60000
 
 # Verify mic and camera remain disabled in meeting room
 - assertVisible:

--- a/.maestro/flows/waiting-room-controls-disabled.yaml
+++ b/.maestro/flows/waiting-room-controls-disabled.yaml
@@ -65,7 +65,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 15000
+    timeout: 30000
 
 # Verify mic and camera remain disabled in meeting room
 - assertVisible:

--- a/.maestro/flows/waiting-room-controls-enabled.yaml
+++ b/.maestro/flows/waiting-room-controls-enabled.yaml
@@ -16,6 +16,9 @@ appId: ${APP_ID}
 
 - inputText: "testroom"
 
+- waitForAnimationToEnd:
+    timeout: 2000
+
 - tapOn:
     id: "join-waiting-room-button"
 
@@ -38,6 +41,9 @@ appId: ${APP_ID}
     id: "username-input"
 
 - inputText: "Test User"
+
+- waitForAnimationToEnd:
+    timeout: 2000
 
 - tapOn:
     id: "join-meeting-button"

--- a/.maestro/flows/waiting-room-controls-enabled.yaml
+++ b/.maestro/flows/waiting-room-controls-enabled.yaml
@@ -45,7 +45,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 30000
+    timeout: 60000
 
 # Verify mic and camera remain enabled in meeting room
 - assertVisible:

--- a/.maestro/flows/waiting-room-controls-enabled.yaml
+++ b/.maestro/flows/waiting-room-controls-enabled.yaml
@@ -1,6 +1,7 @@
 appId: ${APP_ID}
 ---
 - launchApp:
+    clearState: true
     permissions:
       camera: allow
       microphone: allow
@@ -13,6 +14,8 @@ appId: ${APP_ID}
 # Enter a room name
 - tapOn:
     id: "room-name-input"
+
+- eraseText
 
 - inputText: "testroom"
 
@@ -39,6 +42,8 @@ appId: ${APP_ID}
 # Enter username and join meeting
 - tapOn:
     id: "username-input"
+
+- eraseText
 
 - inputText: "Test User"
 

--- a/.maestro/flows/waiting-room-controls-enabled.yaml
+++ b/.maestro/flows/waiting-room-controls-enabled.yaml
@@ -45,7 +45,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "meeting-room-screen"
-    timeout: 15000
+    timeout: 30000
 
 # Verify mic and camera remain enabled in meeting room
 - assertVisible:

--- a/.maestro/flows/waiting-room-controls-enabled.yaml
+++ b/.maestro/flows/waiting-room-controls-enabled.yaml
@@ -6,7 +6,7 @@ appId: ${APP_ID}
       microphone: allow
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "landing-screen"
@@ -21,7 +21,7 @@ appId: ${APP_ID}
     id: "join-waiting-room-button"
 
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 
 - assertVisible:
     id: "waiting-room-screen"
@@ -45,7 +45,7 @@ appId: ${APP_ID}
     id: "join-meeting-button"
 
 - waitForAnimationToEnd:
-    timeout: 10000
+    timeout: 15000
 
 - assertVisible:
     id: "meeting-room-screen"

--- a/.maestro/flows/waiting-room-controls-enabled.yaml
+++ b/.maestro/flows/waiting-room-controls-enabled.yaml
@@ -5,11 +5,10 @@ appId: ${APP_ID}
       camera: allow
       microphone: allow
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "landing-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "landing-screen"
 
 # Enter a room name
 - tapOn:
@@ -20,11 +19,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-waiting-room-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "waiting-room-screen"
     timeout: 10000
-
-- assertVisible:
-    id: "waiting-room-screen"
 
 # Verify mic and camera are enabled by default in waiting room
 - assertVisible:
@@ -44,11 +42,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "join-meeting-button"
 
-- waitForAnimationToEnd:
+- extendedWaitUntil:
+    visible:
+      id: "meeting-room-screen"
     timeout: 15000
-
-- assertVisible:
-    id: "meeting-room-screen"
 
 # Verify mic and camera remain enabled in meeting room
 - assertVisible:

--- a/.maestro/flows/waiting-room-controls-enabled.yaml
+++ b/.maestro/flows/waiting-room-controls-enabled.yaml
@@ -19,11 +19,14 @@ appId: ${APP_ID}
 
 - inputText: "testroom"
 
+- hideKeyboard
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 - tapOn:
     id: "join-waiting-room-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:
@@ -47,11 +50,16 @@ appId: ${APP_ID}
 
 - inputText: "Test User"
 
+- tapOn:
+    id: "waiting-room-screen"
+    point: "50%,55%"
+
 - waitForAnimationToEnd:
     timeout: 2000
 
 - tapOn:
     id: "join-meeting-button"
+    optional: true
 
 - extendedWaitUntil:
     visible:

--- a/VERA/VERAApp/VERA/App/DependencyContainer.swift
+++ b/VERA/VERAApp/VERA/App/DependencyContainer.swift
@@ -101,12 +101,7 @@ final class DependencyContainer {
         userRepository: userRepository,
         advancedSettingsUseCase: advancedSettingsUseCase)
 
-    lazy var goodByePageFactory = GoodByePageFactory(
-        joinRoomUseCase: .init(
-            userRepository: userRepository,
-            cameraPreviewProviderRepository: cameraPreviewProviderRepository,
-            advancedSettingsUseCase: advancedSettingsUseCase),
-        userRepository: userRepository)
+    lazy var goodByePageFactory = GoodByePageFactory()
 
     // MARK: - Meeting Room SDK
 

--- a/VERA/VERAArchiving/VERAArchiving/UI/View/ArchivingAccessibilityID.swift
+++ b/VERA/VERAArchiving/VERAArchiving/UI/View/ArchivingAccessibilityID.swift
@@ -2,10 +2,10 @@
 //  Created by Vonage on 18/5/26.
 //
 
-enum ArchivingAccessibilityID {
-    static let startRecordingButton = "archiving-start-recording-button"
-    static let stopRecordingButton = "archiving-stop-recording-button"
-    static let recordingIndicator = "archiving-recording-indicator"
-    static let archiveList = "archiving-archive-list"
-    static let downloadButton = "archiving-download-button"
+public enum ArchivingAccessibilityID {
+    public static let startRecordingButton = "archiving-start-recording-button"
+    public static let stopRecordingButton = "archiving-stop-recording-button"
+    public static let recordingIndicator = "archiving-recording-indicator"
+    public static let archiveList = "archiving-archive-list"
+    public static let downloadButton = "archiving-download-button"
 }

--- a/VERA/VERACore/VERACore/GoodBye/UI/View models/GoodByeViewModel.swift
+++ b/VERA/VERACore/VERACore/GoodBye/UI/View models/GoodByeViewModel.swift
@@ -22,47 +22,19 @@ public struct GoodByeNavigation {
 }
 
 public final class GoodByeViewModel: ObservableObject {
-    private var cancellables = Set<AnyCancellable>()
     public let roomName: RoomName
-    private let joinRoomUseCase: JoinRoomUseCase
-    private let userRepository: UserRepository
     private let goodByeNavigation: GoodByeNavigation
-
-    @MainActor @Published public var error: AlertItem?
 
     init(
         roomName: RoomName,
-        joinRoomUseCase: JoinRoomUseCase,
-        userRepository: UserRepository,
         goodByeNavigation: GoodByeNavigation
     ) {
         self.roomName = roomName
-        self.joinRoomUseCase = joinRoomUseCase
-        self.userRepository = userRepository
         self.goodByeNavigation = goodByeNavigation
     }
 
-    @BackgroundActor
-    public func joinRoom() async {
-        do {
-            let username = try await userRepository.get()?.name ?? ""
-            let request = JoinRoomRequest(roomName: roomName, userName: username)
-            try await joinRoomUseCase(request)
-        } catch {
-            Task { @MainActor [weak self] in
-                self?.error = AlertItem.genericError(error.localizedDescription)
-            }
-        }
-    }
-
     public func onReenter() {
-        Task { [weak self] in
-            guard let self else { return }
-            await joinRoom()
-            await MainActor.run { [weak self] in
-                self?.goodByeNavigation.onReenter()
-            }
-        }
+        goodByeNavigation.onReenter()
     }
 
     public func onReturnToLanding() {

--- a/VERA/VERACore/VERACore/GoodBye/UI/View/GoodByeViewScreen.swift
+++ b/VERA/VERACore/VERACore/GoodBye/UI/View/GoodByeViewScreen.swift
@@ -4,7 +4,6 @@
 
 import SwiftUI
 import VERACommonUI
-import VERADomain
 
 struct GoodByeViewScreen<ContentView: View>: View {
     @ObservedObject var viewModel: GoodByeViewModel
@@ -23,6 +22,6 @@ struct GoodByeViewScreen<ContentView: View>: View {
             additionalContentView: additionalContentView,
             onReenter: viewModel.onReenter,
             onReturnToLanding: viewModel.onReturnToLanding
-        ).alert(item: $viewModel.error) { $0.view }
+        )
     }
 }

--- a/VERA/VERACore/VERACore/GoodBye/Wireframe/GoodByePageFactory.swift
+++ b/VERA/VERACore/VERACore/GoodBye/Wireframe/GoodByePageFactory.swift
@@ -6,16 +6,7 @@ import SwiftUI
 import VERADomain
 
 public class GoodByePageFactory {
-    private let joinRoomUseCase: JoinRoomUseCase
-    private let userRepository: UserRepository
-
-    public init(
-        joinRoomUseCase: JoinRoomUseCase,
-        userRepository: UserRepository
-    ) {
-        self.joinRoomUseCase = joinRoomUseCase
-        self.userRepository = userRepository
-    }
+    public init() {}
 
     public func make<ContentView: View>(
         roomName: RoomName,
@@ -25,8 +16,6 @@ public class GoodByePageFactory {
     ) -> (view: some View, viewModel: GoodByeViewModel) {
         let viewModel = GoodByeViewModel(
             roomName: roomName,
-            joinRoomUseCase: joinRoomUseCase,
-            userRepository: userRepository,
             goodByeNavigation: .init(
                 onReenter: onReenter,
                 onReturnToLanding: onReturnToLanding))

--- a/VERA/VERACore/VERACore/VeraUI/Components/JoinExistingRoom/JoinExistingRoom.swift
+++ b/VERA/VERACore/VERACore/VeraUI/Components/JoinExistingRoom/JoinExistingRoom.swift
@@ -51,9 +51,9 @@ struct JoinExistingRoom: View {
                     placeholder: String(localized: "Room name", bundle: .veraCore),
                     text: $roomName,
                     state: roomState,
-                    forceLowercase: true
+                    forceLowercase: true,
+                    accessibilityIdentifier: LandingPageAccessibilityID.roomNameInput
                 )
-                .accessibilityIdentifier(LandingPageAccessibilityID.roomNameInput)
 
                 JoinButton(color: joinColor) {
                     roomState = getRoomState(true)

--- a/VERA/VERACore/VERACore/VeraUI/Components/JoinExistingRoom/VonageTextField.swift
+++ b/VERA/VERACore/VERACore/VeraUI/Components/JoinExistingRoom/VonageTextField.swift
@@ -76,6 +76,7 @@ struct VonageTextField: View {
     private var text: Binding<String>
     private var state: VonageTextFieldState
     private let forceLowercase: Bool
+    private let accessibilityIdentifier: String?
 
     @State private var labelWidth: CGFloat = 0
     @FocusState private var isFocused: Bool
@@ -84,12 +85,14 @@ struct VonageTextField: View {
         placeholder: String,
         text: Binding<String>,
         state: VonageTextFieldState,
-        forceLowercase: Bool = false
+        forceLowercase: Bool = false,
+        accessibilityIdentifier: String? = nil
     ) {
         self.placeholder = placeholder
         self.text = text
         self.state = state
         self.forceLowercase = forceLowercase
+        self.accessibilityIdentifier = accessibilityIdentifier
     }
 
     var body: some View {
@@ -111,6 +114,7 @@ struct VonageTextField: View {
                             .focused($isFocused)
                             .foregroundStyle(textColor)
                             .kerning(VonageTextFieldConstants.kerning)
+                            .accessibilityIdentifierIfPresent(accessibilityIdentifier)
                             #if os(iOS)
                                 .textInputAutocapitalization(.never)
                                 .autocorrectionDisabled()
@@ -122,6 +126,7 @@ struct VonageTextField: View {
                             .focused($isFocused)
                             .foregroundStyle(textColor)
                             .kerning(VonageTextFieldConstants.kerning)
+                            .accessibilityIdentifierIfPresent(accessibilityIdentifier)
                     }
                 }
                 .padding(.horizontal, VonageTextFieldConstants.textFieldHorizontalPadding)
@@ -198,6 +203,17 @@ struct VonageTextField: View {
                 VERACommonUIAsset.SemanticColors.tertiary.swiftUIColor
             }
         case .invalid: VERACommonUIAsset.SemanticColors.error.swiftUIColor
+        }
+    }
+}
+
+extension View {
+    @ViewBuilder
+    fileprivate func accessibilityIdentifierIfPresent(_ identifier: String?) -> some View {
+        if let identifier {
+            accessibilityIdentifier(identifier)
+        } else {
+            self
         }
     }
 }

--- a/VERA/VERACore/VERACore/Waiting room/UI/Views/UsernameInput.swift
+++ b/VERA/VERACore/VERACore/Waiting room/UI/Views/UsernameInput.swift
@@ -15,9 +15,9 @@ struct UsernameInput: View {
             VonageTextField(
                 placeholder: String(localized: "Enter your name", bundle: .veraCore),
                 text: $userName,
-                state: usernameState
+                state: usernameState,
+                accessibilityIdentifier: WaitingRoomAccessibilityID.usernameInput
             )
-            .accessibilityIdentifier(WaitingRoomAccessibilityID.usernameInput)
         }
         .onChange(of: userName) { _ in
             withAnimation(.easeInOut(duration: 0.2)) {

--- a/VERA/VERAMeetingRoom/VERAMeetingRoom/UI/Components/BottomBar.swift
+++ b/VERA/VERAMeetingRoom/VERAMeetingRoom/UI/Components/BottomBar.swift
@@ -31,19 +31,23 @@ public enum BottomBarConstants {
 public struct BottomBarButton: Identifiable {
     public let id: String
     public let label: String
+    public let accessibilityIdentifier: String?
     public let image: Image
     public let content: () -> AnyView
     public let overlay: (() -> AnyView)?
     public let onTap: () -> Void
 
     public init<Content: View>(
+        id: String? = nil,
         label: String,
+        accessibilityIdentifier: String? = nil,
         image: Image,
         onTap: @escaping () -> Void,
         @ViewBuilder content: @escaping () -> Content
     ) {
-        self.id = label
+        self.id = id ?? label
         self.label = label
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.image = image
         self.onTap = onTap
         self.content = { AnyView(content()) }
@@ -51,14 +55,17 @@ public struct BottomBarButton: Identifiable {
     }
 
     public init<Content: View, Overlay: View>(
+        id: String? = nil,
         label: String,
+        accessibilityIdentifier: String? = nil,
         image: Image,
         onTap: @escaping () -> Void,
         @ViewBuilder content: @escaping () -> Content,
         @ViewBuilder overlay: @escaping () -> Overlay
     ) {
-        self.id = label
+        self.id = id ?? label
         self.label = label
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.image = image
         self.onTap = onTap
         self.content = { AnyView(content()) }
@@ -238,6 +245,7 @@ struct BottomBar: View {
                                 }
                             }
                         }
+                        .accessibilityIdentifier(button.accessibilityIdentifier ?? button.id)
                     }
                 } label: {
                     ButtonImage(image: Image(systemName: "ellipsis.circle"))

--- a/VERA/VERAMeetingRoomSDK/VERAMeetingRoomSDK/BottomBarButtonsAssembler.swift
+++ b/VERA/VERAMeetingRoomSDK/VERAMeetingRoomSDK/BottomBarButtonsAssembler.swift
@@ -141,9 +141,16 @@ final class BottomBarButtonsAssembler {
         _ state: MeetingRoomButtonsState
     ) -> BottomBarButton {
         let button = container.archivingFactory.makeArchivingButton(viewModel: viewModel)
+        let isArchiving = state.archivingState.isArchiving
+        let accessibilityIdentifier =
+            isArchiving
+            ? ArchivingAccessibilityID.stopRecordingButton
+            : ArchivingAccessibilityID.startRecordingButton
         return .init(
-            label: state.archivingState.isArchiving
+            id: accessibilityIdentifier,
+            label: isArchiving
                 ? String(localized: "Stop Recording") : String(localized: "Start Recording"),
+            accessibilityIdentifier: accessibilityIdentifier,
             image: VERACommonUIAsset.Images.radioChecked2Line.swiftUIImage,
             onTap: viewModel.onTap,
             content: {

--- a/VERA/VERAVonage/VERAVonage/DefaultRoomCredentialsRepository.swift
+++ b/VERA/VERAVonage/VERAVonage/DefaultRoomCredentialsRepository.swift
@@ -27,7 +27,7 @@ public final actor DefaultRoomCredentialsRepository: RoomCredentialsRepository {
     private let jsonDecoder: JSONDecoder
     private let jsonEncoder: JSONEncoder
     private let baseURL: URL
-    private var cache: [String: RoomCredentialsResponse] = [:]
+    private var sessionCache: [String: CreateSessionResponse] = [:]
 
     public init(
         baseURL: URL,
@@ -42,19 +42,10 @@ public final actor DefaultRoomCredentialsRepository: RoomCredentialsRepository {
     }
 
     public func getRoomCredentials(_ request: RoomCredentialsRequest) async throws -> RoomCredentialsResponse {
-        if let cached = cache[request.roomName] {
-            return cached
-        }
-
-        let createBody = try jsonEncoder.encode(CreateSessionRequestBody(roomName: request.roomName))
-        let createData = try await httpClient.post(
-            baseURL.appendingPathComponent("v2").appendingPathComponent("createSession"),
-            data: createBody)
-        let createResponse = try jsonDecoder.decode(
-            TRPCResponse<CreateSessionResponse>.self, from: createData)
+        let createResponse = try await getOrCreateSession(for: request.roomName)
 
         let joinBody = try jsonEncoder.encode(
-            JoinSessionRequestBody(sessionKey: createResponse.result.data.sessionKey))
+            JoinSessionRequestBody(sessionKey: createResponse.sessionKey))
         let joinData = try await httpClient.post(
             baseURL.appendingPathComponent("v2").appendingPathComponent("joinSession"),
             data: joinBody)
@@ -62,13 +53,26 @@ public final actor DefaultRoomCredentialsRepository: RoomCredentialsRepository {
             TRPCResponse<JoinSessionResponse>.self, from: joinData)
 
         let credentials = RoomCredentialsResponse(
-            sessionId: createResponse.result.data.sessionId,
+            sessionId: createResponse.sessionId,
             token: joinResponse.result.data.token,
-            apiKey: createResponse.result.data.applicationId,
-            sessionKey: createResponse.result.data.sessionKey)
-
-        cache[request.roomName] = credentials
-
+            apiKey: createResponse.applicationId,
+            sessionKey: createResponse.sessionKey)
         return credentials
+    }
+
+    private func getOrCreateSession(for roomName: String) async throws -> CreateSessionResponse {
+        if let cached = sessionCache[roomName] {
+            return cached
+        }
+
+        let createBody = try jsonEncoder.encode(CreateSessionRequestBody(roomName: roomName))
+        let createData = try await httpClient.post(
+            baseURL.appendingPathComponent("v2").appendingPathComponent("createSession"),
+            data: createBody)
+        let createResponse = try jsonDecoder.decode(
+            TRPCResponse<CreateSessionResponse>.self, from: createData)
+
+        sessionCache[roomName] = createResponse.result.data
+        return createResponse.result.data
     }
 }

--- a/VERA/VERAVonage/VERAVonageTests/DefaultRoomCredentialsRepositoryTests.swift
+++ b/VERA/VERAVonage/VERAVonageTests/DefaultRoomCredentialsRepositoryTests.swift
@@ -115,15 +115,23 @@ struct DefaultRoomCredentialsRepositoryTests {
         #expect(httpClient.callCount == 2)
     }
 
-    @Test("Caches credentials for same room")
-    func cachesCredentialsForSameRoom() async throws {
-        let httpClient = try makeHTTPClientWithResponses()
+    @Test("Caches session but refreshes join token for same room")
+    func cachesSessionButRefreshesJoinTokenForSameRoom() async throws {
+        let httpClient = MockHTTPClient()
+        httpClient.dataSequence = [
+            try makeCreateSessionJSONResponse(),
+            try makeJoinSessionJSONResponse(token: "token-1"),
+            try makeJoinSessionJSONResponse(token: "token-2"),
+        ]
 
         let sut = makeSUT(httpClient: httpClient)
-        _ = try await sut.getRoomCredentials(makeRoomCredentialsRequest(roomName: "room"))
-        _ = try await sut.getRoomCredentials(makeRoomCredentialsRequest(roomName: "room"))
+        let firstCredentials = try await sut.getRoomCredentials(makeRoomCredentialsRequest(roomName: "room"))
+        let secondCredentials = try await sut.getRoomCredentials(makeRoomCredentialsRequest(roomName: "room"))
 
-        #expect(httpClient.callCount == 2)
+        #expect(httpClient.callCount == 3)
+        #expect(httpClient.recordedURLs.map(\.lastPathComponent) == ["createSession", "joinSession", "joinSession"])
+        #expect(firstCredentials.token == "token-1")
+        #expect(secondCredentials.token == "token-2")
     }
 
     @Test("Different rooms are fetched independently")

--- a/scripts/run-maestro-tests.sh
+++ b/scripts/run-maestro-tests.sh
@@ -432,7 +432,7 @@ echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━�
 echo -e "${BLUE}   🧪 Running Maestro UI Tests${NC}"
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
 
-if maestro test --device "$SIMULATOR_ID" --env APP_ID="$APP_ID" "$FLOW_TARGET"; then
+if maestro test --config .maestro/config.yaml --device "$SIMULATOR_ID" --env APP_ID="$APP_ID" "$FLOW_TARGET"; then
     TEST_RESULT=0
 else
     TEST_RESULT=$?

--- a/scripts/run-maestro-tests.sh
+++ b/scripts/run-maestro-tests.sh
@@ -102,7 +102,8 @@ if ! command -v xcodebuild &> /dev/null; then
     exit 1
 fi
 
-XCODE_VERSION=$(xcodebuild -version | head -n 1)
+XCODE_VERSION_OUTPUT=$(xcodebuild -version)
+XCODE_VERSION="${XCODE_VERSION_OUTPUT%%$'\n'*}"
 echo -e "${GREEN}✓ $XCODE_VERSION detected${NC}"
 
 echo ""

--- a/scripts/run-maestro-tests.sh
+++ b/scripts/run-maestro-tests.sh
@@ -345,6 +345,11 @@ else
     echo -e "${GREEN}✓ Simulator ready${NC}"
 fi
 
+# Disable simulator animations for faster CI
+echo -e "${YELLOW}⚡ Disabling simulator animations...${NC}"
+xcrun simctl spawn "$SIMULATOR_ID" defaults write com.apple.springboard SBAnimationSpeed 1000
+echo -e "${GREEN}✓ Animations disabled${NC}"
+
 # Terminate app if running
 echo -e "${YELLOW}⏹️  Closing app if running...${NC}"
 xcrun simctl terminate "$SIMULATOR_ID" "com.vonage.VERA" 2>/dev/null || true

--- a/scripts/run-maestro-tests.sh
+++ b/scripts/run-maestro-tests.sh
@@ -366,6 +366,17 @@ fi
 
 echo -e "${GREEN}✓ App installed successfully${NC}\n"
 
+echo -e "${BLUE}🔎 Verifying installed app...${NC}"
+echo -e "${BLUE}   Built app bundle identifier:${NC}"
+/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" "$APP_PATH/Info.plist" 2>/dev/null || echo "Unable to read CFBundleIdentifier from $APP_PATH/Info.plist"
+
+echo -e "${BLUE}   Installed app container:${NC}"
+xcrun simctl get_app_container "$SIMULATOR_ID" "$APP_ID" app 2>&1 || true
+
+echo -e "${BLUE}   Installed app registration:${NC}"
+xcrun simctl listapps "$SIMULATOR_ID" 2>/dev/null | grep -A 5 -B 5 "$APP_ID" || true
+echo ""
+
 # Grant permissions via simctl (reliable in CI, persists across clearState)
 echo -e "${YELLOW}🔐 Granting camera and microphone permissions...${NC}"
 xcrun simctl privacy "$SIMULATOR_ID" grant camera "$APP_ID"

--- a/scripts/run-maestro-tests.sh
+++ b/scripts/run-maestro-tests.sh
@@ -116,21 +116,32 @@ APP_ID="com.vonage.VERA"
 WORKSPACE="VERA/VERA.xcworkspace"
 BUILD_DIR="DerivedData"
 
+find_simulator_id() {
+    xcrun simctl list devices available | awk -v device="$1" '
+        $0 ~ "^[[:space:]]*" device " \\(" {
+            if (match($0, /\([A-F0-9-]+\)/)) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                exit
+            }
+        }
+    '
+}
+
 # Auto-detect simulator: use env var, or find best available iPhone
 if [ -n "$SIMULATOR_DEVICE" ]; then
     DEVICE="$SIMULATOR_DEVICE"
 else
     echo -e "${BLUE}🔍 Auto-detecting simulator...${NC}"
     
-    if xcrun simctl list devices available | grep -q "iPhone 17"; then
+    if [ -n "$(find_simulator_id "iPhone 17")" ]; then
         DEVICE="iPhone 17"
-    elif xcrun simctl list devices available | grep -q "iPhone 16 Pro"; then
+    elif [ -n "$(find_simulator_id "iPhone 16 Pro")" ]; then
         DEVICE="iPhone 16 Pro"
-    elif xcrun simctl list devices available | grep -q "iPhone 16"; then
+    elif [ -n "$(find_simulator_id "iPhone 16")" ]; then
         DEVICE="iPhone 16"
-    elif xcrun simctl list devices available | grep -q "iPhone 15 Pro"; then
+    elif [ -n "$(find_simulator_id "iPhone 15 Pro")" ]; then
         DEVICE="iPhone 15 Pro"
-    elif xcrun simctl list devices available | grep -q "iPhone 15"; then
+    elif [ -n "$(find_simulator_id "iPhone 15")" ]; then
         DEVICE="iPhone 15"
     else
         DEVICE=$(xcrun simctl list devices available | grep "iPhone" | head -n 1 | sed 's/^ *//' | sed 's/ (.*//')
@@ -144,9 +155,21 @@ else
     fi
 fi
 
+SIMULATOR_ID=$(find_simulator_id "$DEVICE")
+
+if [ -z "$SIMULATOR_ID" ]; then
+    echo -e "${RED}❌ Could not get simulator ID for '$DEVICE'${NC}"
+    echo -e "${YELLOW}Available simulators:${NC}"
+    xcrun simctl list devices available | grep "iPhone"
+    echo ""
+    echo -e "${YELLOW}💡 Use: SIMULATOR_DEVICE=\"iPhone 16\" ./scripts/run-maestro-tests.sh${NC}"
+    exit 1
+fi
+
 echo -e "${BLUE}Configuration:${NC}"
 echo -e "  Xcode:      ${GREEN}$XCODE_VERSION${NC}"
 echo -e "  Device:     ${GREEN}$DEVICE${NC}"
+echo -e "  Device ID:  ${GREEN}$SIMULATOR_ID${NC}"
 echo -e "  Scheme:     ${GREEN}$APP_SCHEME${NC}"
 echo -e "  Workspace:  ${GREEN}$WORKSPACE${NC}"
 echo ""
@@ -275,7 +298,7 @@ if [ -z "$APP_PATH" ]; then
     if ! xcodebuild clean build \
       -workspace "$WORKSPACE" \
       -scheme "$APP_SCHEME" \
-      -destination "platform=iOS Simulator,name=$DEVICE" \
+      -destination "id=$SIMULATOR_ID" \
       -derivedDataPath "$BUILD_DIR" \
       CODE_SIGN_IDENTITY="" \
       CODE_SIGNING_REQUIRED=NO \
@@ -309,24 +332,6 @@ echo -e "${BLUE}📱 App path: $APP_PATH${NC}\n"
 # ============================================================================
 
 echo -e "${YELLOW}🚀 Managing simulator '$DEVICE'...${NC}"
-
-# Validate simulator exists
-if ! xcrun simctl list devices available | grep -q "$DEVICE"; then
-    echo -e "${RED}❌ Simulator '$DEVICE' not available${NC}"
-    echo -e "${YELLOW}Available simulators:${NC}"
-    xcrun simctl list devices available | grep "iPhone"
-    echo ""
-    echo -e "${YELLOW}💡 Use: SIMULATOR_DEVICE=\"iPhone 16\" ./scripts/run-maestro-tests.sh${NC}"
-    exit 1
-fi
-
-# Get simulator UUID for reliable operations
-SIMULATOR_ID=$(xcrun simctl list devices available | grep "$DEVICE" | head -n 1 | grep -oE '\([A-F0-9-]+\)' | tr -d '()')
-
-if [ -z "$SIMULATOR_ID" ]; then
-    echo -e "${RED}❌ Could not get simulator ID for '$DEVICE'${NC}"
-    exit 1
-fi
 
 echo -e "${GREEN}✓ Found simulator: $DEVICE ($SIMULATOR_ID)${NC}"
 
@@ -391,7 +396,7 @@ echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━�
 echo -e "${BLUE}   🧪 Running Maestro UI Tests${NC}"
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
 
-if maestro test --env APP_ID="$APP_ID" "$FLOW_TARGET"; then
+if maestro test --device "$SIMULATOR_ID" --env APP_ID="$APP_ID" "$FLOW_TARGET"; then
     TEST_RESULT=0
 else
     TEST_RESULT=$?

--- a/scripts/run-maestro-tests.sh
+++ b/scripts/run-maestro-tests.sh
@@ -115,6 +115,15 @@ APP_SCHEME=${APP_SCHEME:-"VERA"}
 APP_ID="com.vonage.VERA"
 WORKSPACE="VERA/VERA.xcworkspace"
 BUILD_DIR="DerivedData"
+LOG_PIDS=()
+
+stop_live_logs() {
+    if [ ${#LOG_PIDS[@]} -gt 0 ]; then
+        kill "${LOG_PIDS[@]}" 2>/dev/null || true
+        wait "${LOG_PIDS[@]}" 2>/dev/null || true
+        LOG_PIDS=()
+    fi
+}
 
 find_simulator_id() {
     xcrun simctl list devices available | awk -v device="$1" '
@@ -388,6 +397,32 @@ xcrun simctl privacy "$SIMULATOR_ID" grant camera "$APP_ID"
 xcrun simctl privacy "$SIMULATOR_ID" grant microphone "$APP_ID"
 echo -e "${GREEN}✓ Permissions granted${NC}\n"
 
+if [ -n "${MAESTRO_LOG_DIR:-}" ]; then
+    mkdir -p "$MAESTRO_LOG_DIR"
+
+    echo -e "${BLUE}🪵 Capturing simulator logs in $MAESTRO_LOG_DIR...${NC}"
+
+    APP_LOG_PREDICATE='process == "VERA" OR subsystem CONTAINS "com.vonage" OR senderImagePath CONTAINS "/VERA.app/" OR eventMessage CONTAINS[c] "VERA"'
+    SYSTEM_LOG_PREDICATE='process == "SpringBoard" OR subsystem CONTAINS "com.apple.frontboard" OR subsystem CONTAINS "com.apple.runningboard" OR subsystem CONTAINS "com.apple.launchservices"'
+
+    xcrun simctl spawn "$SIMULATOR_ID" log stream \
+        --style compact \
+        --level debug \
+        --predicate "$APP_LOG_PREDICATE" \
+        > "$MAESTRO_LOG_DIR/vera-app-live.log" 2>&1 &
+    LOG_PIDS+=($!)
+
+    xcrun simctl spawn "$SIMULATOR_ID" log stream \
+        --style compact \
+        --level debug \
+        --predicate "$SYSTEM_LOG_PREDICATE" \
+        > "$MAESTRO_LOG_DIR/simulator-live.log" 2>&1 &
+    LOG_PIDS+=($!)
+
+    trap stop_live_logs EXIT
+    echo -e "${GREEN}✓ Live log capture started${NC}\n"
+fi
+
 # ============================================================================
 # 7. Run Maestro Tests
 # ============================================================================
@@ -400,6 +435,22 @@ if maestro test --device "$SIMULATOR_ID" --env APP_ID="$APP_ID" "$FLOW_TARGET"; 
     TEST_RESULT=0
 else
     TEST_RESULT=$?
+fi
+
+if [ -n "${MAESTRO_LOG_DIR:-}" ]; then
+    stop_live_logs
+
+    xcrun simctl spawn "$SIMULATOR_ID" log show \
+        --last 30m \
+        --style compact \
+        --predicate "$APP_LOG_PREDICATE" \
+        > "$MAESTRO_LOG_DIR/vera-app-history.log" 2>&1 || true
+
+    xcrun simctl spawn "$SIMULATOR_ID" log show \
+        --last 30m \
+        --style compact \
+        --predicate "$SYSTEM_LOG_PREDICATE" \
+        > "$MAESTRO_LOG_DIR/simulator-history.log" 2>&1 || true
 fi
 
 echo ""

--- a/scripts/run-maestro-tests.sh
+++ b/scripts/run-maestro-tests.sh
@@ -348,6 +348,8 @@ fi
 # Disable simulator animations for faster CI
 echo -e "${YELLOW}⚡ Disabling simulator animations...${NC}"
 xcrun simctl spawn "$SIMULATOR_ID" defaults write com.apple.springboard SBAnimationSpeed 1000
+xcrun simctl spawn "$SIMULATOR_ID" defaults write com.apple.UIKit UIAnimationDragCoefficient 0
+xcrun simctl spawn "$SIMULATOR_ID" defaults write -g AppleReduceMotionEnabled -bool true
 echo -e "${GREEN}✓ Animations disabled${NC}"
 
 # Terminate app if running


### PR DESCRIPTION
#### What is this PR doing?

Disables UI animations during Maestro E2E tests to reduce flaky timeouts caused by slow CI simulators.

### Commit
- `66d9c6bb` ci: disable simulator animations in Maestro tests for faster CI

### Problem
Maestro flows (especially recording.yaml) were failing intermittently in CI because `waitForAnimationToEnd` timeouts expired before the simulator finished animating. The `recording` flow failed at `assertVisible: archiving-recording-indicator` because the confirmation alert hadn't dismissed in time — taps on "Start Recording" and "OK" each took ~60s on the CI simulator.

### Changes

**config.yaml**
- Add `platform.ios.disableAnimations: true` — instructs Maestro's XCUITest driver to skip UIKit animations during test execution

**run-maestro-tests.sh**
- Add `SBAnimationSpeed 1000` on the simulator's SpringBoard after boot — disables system-level transition animations (app launch, alerts, navigation)

#### How should this be manually tested?

- Run `.run-maestro-tests.sh recording.yaml` locally — the recording flow should complete without timeout failures
- Observe faster transitions between screens (no animation delays)
- All other flows should continue passing as before