### PR TITLE
VIDSOL-1038: Fix e2e test speaking-while-muted.yaml

### DIFF
--- a/.maestro/flows/speaking-while-muted.yaml
+++ b/.maestro/flows/speaking-while-muted.yaml
@@ -49,12 +49,15 @@ appId: ${APP_ID}
 - assertVisible:
     id: "meeting-room-mic-enabled"
 
-# Mute the microphone — E2E mock will start simulating loud audio
+# Mute the microphone — E2E mock will start simulating loud audio.
+# Toast lifetime is ~4.5s (ToastModifier: visibleDuration=3s + resetDelay=1.5s)
+# and SpeakingWhileMutedDetector only emits once due to `removeDuplicates`,
+# so the steps around the toast check must NOT burn that budget.
+# We skip `waitForAnimationToEnd` after the tap because the meeting room has
+# continuous video/UI animation and it would exhaust its full timeout every
+# time. `assertVisible` already retries and re-checks the hierarchy.
 - tapOn:
     id: "meeting-room-mic-enabled"
-
-- waitForAnimationToEnd:
-    timeout: 2000
 
 # Verify mic is now disabled
 - assertVisible:
@@ -68,25 +71,22 @@ appId: ${APP_ID}
       id: "toast-warning"
     timeout: 10000
 
-- assertVisible:
-    id: "toast-warning"
-
 - takeScreenshot: 03-speaking-while-muted-toast
 
-# Unmute the microphone — toast should disappear
+# Unmute the microphone — toast will auto-dismiss on its own timer
 - tapOn:
     id: "meeting-room-mic-disabled"
-
-- waitForAnimationToEnd:
-    timeout: 5000
 
 # Verify mic is enabled again
 - assertVisible:
     id: "meeting-room-mic-enabled"
 
-# Toast should no longer be visible (auto-dismissed or state reset)
-- assertNotVisible:
-    id: "toast-warning"
+# Toast auto-dismisses ~4.5s after first appearing. Wait explicitly for it
+# instead of relying on Maestro's default assertNotVisible retry window.
+- extendedWaitUntil:
+    notVisible:
+      id: "toast-warning"
+    timeout: 6000
 
 - takeScreenshot: 04-unmuted-no-toast
 


### PR DESCRIPTION
#### What is this PR doing?

- Remove waitForAnimationToEnd(2000) after mute tap: meeting room has continuous UI/video animation so this step always exhausted its full timeout, burning ~2.5s of the toast's 4.5s lifetime budget.
- Remove waitForAnimationToEnd(5000) after unmute tap for the same reason.
- Remove redundant assertVisible(toast-warning) that raced the auto-dismiss window of ToastModifier (visibleDuration=3s, resetDelay=4.5s).
- Replace assertNotVisible with extendedWaitUntil notVisible timeout:6000 for an explicit, deterministic wait on the toast auto-dismiss.

Root cause: SpeakingWhileMutedDetector only emits true once via .removeDuplicates(), so the toast appears exactly once per mute cycle. Between the mute tap resolution (~1.4s in Maestro) and the animation wait steps consuming ~2.5s more, Maestro was left with <700ms margin before the toast auto-dismissed — making the test timing-sensitive on CI.

#### How should this be manually tested?

sh run-maestro-tests.sh speaking-while-muted.yaml

#### What are the relevant tickets?

[VIDSOL-1038](https://jira.vonage.com/browse/VIDSOL-1038)